### PR TITLE
docs: add Jest→Vitest migration planning and update repo naming across docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // See https://containers.dev/ for full reference
 {
-  "name": "AssessmentBot-Backend DevContainer",
+  "name": "Assessment Bot LLM Service DevContainer",
   // Use the typescript-node base image (Node.js + TypeScript tooling).
   // Keep the Ubuntu variant behavior from the original image where applicable.
   "image": "mcr.microsoft.com/devcontainers/typescript-node:latest",

--- a/.github/copilot/agent-config.yml
+++ b/.github/copilot/agent-config.yml
@@ -10,7 +10,7 @@ environment:
   # Environment variables required for development and testing
   variables:
     NODE_ENV: "development"
-    APP_NAME: "AssessmentBot-Backend"
+    APP_NAME: "Assessment Bot LLM Service"
     APP_VERSION: "1.0.0"
     LOG_LEVEL: "debug"
     PORT: "3000"

--- a/.opencode/plugins/no-eslint-silence.ts
+++ b/.opencode/plugins/no-eslint-silence.ts
@@ -9,6 +9,12 @@ const SILENCE_PATTERNS = [
   /type:\s*ignore/i,
 ];
 
+/**
+ * Check whether the given text contains any silencing rule patterns.
+ * @param {string} text - The text to check for silencing rules.
+ * @returns {string | null} The matched pattern source, or null if no silencing
+ *   rule is found.
+ */
 function hasSilencingRule(text: string): string | null {
   for (const pattern of SILENCE_PATTERNS) {
     if (pattern.test(text)) return pattern.source;

--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -1,0 +1,720 @@
+# ACTION_PLAN: Eliminate CommonJS Module Exports — Full ESM Migration
+
+This plan is organised into small, independently testable sections. Each section follows TDD ordering (Red → Green → Refactor) where applicable. Sections are ordered so that enabling infrastructure lands before dependent work.
+
+**Reference:** `SPEC.md` — decisions D1–D8, constraints C1–C7, state rules S1–S7.
+
+---
+
+## Section 0: Phase 0 — Validation and De-risking
+
+**Objective:** Validate that the core technology assumptions hold before any bulk migration begins. This section produces no production code changes — only proof-of-concept validations.
+
+**Constraints:**
+
+- Do not modify any source files permanently.
+- Use temporary branches or scratch files for validation.
+- Roll back all temporary changes after validation.
+
+**Acceptance Criteria:**
+
+1. A minimal NestJS app with `emitDecoratorMetadata: true` and `"module": "NodeNext"` compiles and starts successfully.
+2. `@nestjs/testing`'s `Test.createTestingModule()` works under Vitest with ESM output.
+3. `nest build` produces valid ESM output when `tsconfig.json` uses `"module": "NodeNext"`.
+4. `node dist/src/main.js` starts the minimal app as ESM.
+5. `reflect-metadata` import ordering works correctly under ESM.
+6. **Vitest's default transformer preserves decorator metadata** (critical — see R8 in SPEC.md).
+
+**Validation Steps:**
+
+1. **NestJS ESM compilation check:**
+   - Create a temporary copy of `tsconfig.json` with `"module": "NodeNext"` and `"moduleResolution": "NodeNext"`.
+   - Run `npx tsc --noEmit` against a minimal NestJS module (e.g., `AppModule` with a single controller).
+   - Verify no compilation errors related to decorator metadata or module resolution.
+
+2. **NestJS TestingModule under Vitest (CRITICAL):**
+   - Install `vitest` temporarily (`npm install --save-dev vitest`).
+   - Create a temporary `vitest.config.ts` and a minimal spec file that uses `Test.createTestingModule()` with constructor injection (no explicit `@Inject()` decorators).
+   - Run the spec. Verify `TestingModule` compiles AND correctly resolves dependencies via constructor injection.
+   - **If DI fails:** This confirms risk R8. The fix is either:
+     - Configure Vitest to use `tsc` as the transformer (preserves `emitDecoratorMetadata`).
+     - Or add explicit `@Inject()` decorators to all constructor parameters in the codebase (significant code change — requires user approval).
+   - Document the result before proceeding.
+
+3. **`nest build` ESM output:**
+   - With the temporary `tsconfig.json`, run `npm run build`.
+   - Inspect `dist/` output — verify files use `import`/`export` syntax (not `require`/`module.exports`).
+   - Run `node dist/src/main.js` — verify it starts without errors.
+
+4. **`reflect-metadata` ordering:**
+   - Verify that `import 'reflect-metadata'` at the top of `main.ts` (before any NestJS imports) works correctly under ESM.
+   - Verify decorator metadata is emitted and resolved by NestJS's dependency injection.
+
+**Section Checks:**
+
+- [ ] All 5 acceptance criteria pass.
+- [ ] Temporary changes are rolled back.
+- [ ] Any issues discovered are recorded as blockers before proceeding.
+
+**Blockers if validation fails:**
+
+- If NestJS decorator metadata fails under ESM: investigate `tsconfig.json` `emitDecoratorMetadata` interaction with `NodeNext`. May need `"module": "ESNext"` instead.
+- If `TestingModule` fails under Vitest: **This is the critical risk (R8).** If Vitest's default transformer doesn't preserve decorator metadata, you must either:
+  1. Configure Vitest to use `tsc` as the transformer (preserves `emitDecoratorMetadata`).
+  2. Or add explicit `@Inject()` decorators to all constructor parameters in the codebase (significant code change — requires user approval before proceeding).
+- If `reflect-metadata` import ordering fails: ensure it's imported first in setup files and entry points.
+
+---
+
+## Section 1: TypeScript and Package Configuration
+
+**Objective:** Switch the TypeScript compilation target to ESM and update `package.json` to declare the package as ESM.
+
+**Constraints:**
+
+- Tests will break after this section (Jest cannot run ESM output without significant configuration). This is expected. Section 2 will fix the tests.
+- The production build must still compile successfully.
+- Do not change any source code logic in this section.
+
+**Acceptance Criteria:**
+
+1. `tsconfig.json` uses `"module": "NodeNext"` and `"moduleResolution": "NodeNext"`.
+2. `tsconfig.json` `types` array no longer includes `"jest"`.
+3. `tsconfig.test.json` is deleted.
+4. `package.json` has `"type": "module"`.
+5. `npm run build` succeeds and produces ESM output in `dist/`.
+6. `node dist/src/main.js` starts the application (validates ESM entry-point detection works).
+
+**Red-First Tests (not applicable for infrastructure):**
+This section is configuration-only. Verification is via build and runtime checks.
+
+**Green — Implementation Steps:**
+
+1. **Update `tsconfig.json`:**
+   - Change `"module": "CommonJS"` → `"module": "NodeNext"`.
+   - Change `"moduleResolution": "node"` → `"moduleResolution": "NodeNext"`.
+   - Change `"types": ["node", "jest"]` → `"types": ["node"]`.
+   - Remove `"ignoreDeprecations": "6.0"` if no longer needed.
+   - Note: `tsconfig.build.json` extends `tsconfig.json` and overrides `types` to `["node"]`. After this change, the override becomes redundant (base already has `["node"]`). No change needed to `tsconfig.build.json`, but the redundant override can be cleaned up.
+
+2. **Delete `tsconfig.test.json`:**
+   - This file exists solely for Jest ESM overrides. No longer needed.
+
+3. **Update `package.json`:**
+   - Add `"type": "module"`.
+
+4. **Update `src/main.ts` — ESM entry-point detection:**
+   - Replace `isRunningDirectly()` implementation:
+     ```typescript
+     import { pathToFileURL } from 'node:url';
+
+     function isRunningDirectly(): boolean {
+       return (
+         process.argv[1] != null &&
+         import.meta.url === pathToFileURL(process.argv[1]).href
+       );
+     }
+     ```
+   - Remove the `!process.env.JEST_WORKER_ID` check.
+
+5. **Update `src/testing-main.ts` — ESM entry-point detection:**
+   - Same pattern as `main.ts`.
+
+6. **Convert `scripts/health-check.js` to ESM:**
+   - Replace `const http = require('node:http')` with `import http from 'node:http'`.
+
+7. **Verify build and runtime:**
+   - Run `npm run build` — must succeed.
+   - Inspect `dist/src/main.js` — must use `import`/`export` syntax.
+   - Run `node dist/src/main.js` — must start the server.
+
+**Refactor:**
+
+- Review any TypeScript compilation errors that arise from `NodeNext` module resolution (e.g., missing `.js` extensions in relative imports). Fix them.
+
+**Section Checks:**
+
+- [ ] `npm run build` succeeds.
+- [ ] `dist/` output uses ESM syntax.
+- [ ] `node dist/src/main.js` starts the server.
+- [ ] No `require()` or `module.exports` in any source file.
+- [ ] `tsconfig.test.json` is deleted.
+
+---
+
+## Section 2: Test Runner Migration — Infrastructure
+
+**Objective:** Replace Jest with Vitest. Create the Vitest configuration and setup files. Remove all Jest configuration files and dependencies.
+
+**Constraints:**
+
+- Tests will not pass until Section 3 (test file migration) is complete.
+- Install Vitest and remove Jest in a single commit to avoid a broken intermediate state.
+
+**Acceptance Criteria:**
+
+1. `vitest` and `@vitest/coverage-v8` are installed as dev dependencies.
+2. All Jest packages are removed (`jest`, `@types/jest`, `ts-jest`, `jest-junit`, `eslint-plugin-jest`).
+3. All Jest config files are deleted (`jest.config.js`, `jest-e2e.*.config.cjs`, `jest-prod.config.cjs`, `jest.setup.ts`, `test/jest.e2e.*.setup.ts`).
+4. `vitest.workspace.ts` (or separate config files) is created.
+5. `vitest.setup.ts` is created with environment variable setup (migrating `jest.setup.ts` logic).
+6. `npm run test` invokes Vitest (even if tests fail due to un-migrated API calls).
+
+**Red-First Tests:**
+
+- After removing Jest and installing Vitest, running `npm run test` should invoke Vitest. Tests will fail because spec files still use `jest.*` APIs. This is the expected "red" state.
+
+**Green — Implementation Steps:**
+
+1. **Install Vitest:**
+
+   ```bash
+   npm install --save-dev vitest @vitest/coverage-v8
+   ```
+
+2. **Remove Jest dependencies:**
+
+   ```bash
+   npm uninstall jest @types/jest ts-jest jest-junit eslint-plugin-jest
+   ```
+
+3. **Install ESLint Vitest plugin:**
+
+   ```bash
+   npm install --save-dev eslint-plugin-vitest
+   ```
+
+4. **Delete Jest configuration files:**
+   - `jest.config.js`
+   - `jest-e2e.mocked.config.cjs`
+   - `jest-e2e.live.config.cjs`
+   - `jest-e2e.config.cjs`
+   - `jest-prod.config.cjs`
+   - `jest.setup.ts`
+   - `test/jest.e2e.mocked.setup.ts`
+   - `test/jest.e2e.live.setup.ts`
+
+5. **Create `vitest.setup.ts`:**
+   - Migrate environment variable setup from `jest.setup.ts`.
+   - Add `import 'reflect-metadata'` as the FIRST import (before any other imports) to ensure NestJS decorator metadata works correctly under ESM (addresses risk R6).
+     ```typescript
+     import 'reflect-metadata';
+     import * as dotenv from 'dotenv';
+     dotenv.config({ path: '.test.env' });
+
+     process.env.GEMINI_API_KEY = 'test-key';
+     process.env.NODE_ENV = 'test';
+     process.env.PORT = '3000';
+     process.env.API_KEYS = 'test-api-key';
+     process.env.MAX_IMAGE_UPLOAD_SIZE_MB = '5';
+     process.env.ALLOWED_IMAGE_MIME_TYPES = 'image/png,image/jpeg';
+     process.env.LOG_LEVEL = 'debug';
+     process.env.THROTTLER_TTL = '60';
+     process.env.UNAUTHENTICATED_THROTTLER_LIMIT = '10';
+     process.env.AUTHENTICATED_THROTTLER_LIMIT = '50';
+     ```
+
+6. **Create `vitest.workspace.ts`** (preferred) or separate config files:
+   - Workspace approach:
+     ```typescript
+     import { defineWorkspace } from 'vitest/config';
+
+     export default defineWorkspace([
+       {
+         test: {
+           name: 'unit',
+           root: '.',
+           include: ['src/**/*.spec.ts'],
+           setupFiles: ['./vitest.setup.ts'],
+           globals: true,
+           reporters: ['default', 'junit'],
+           outputFile: './junit/vitest-junit.xml',
+         },
+       },
+       {
+         test: {
+           name: 'e2e',
+           root: '.',
+           include: ['test/**/*.e2e-spec.ts'],
+           exclude: ['test/**/*-live.e2e-spec.ts', 'test/prod-tests/**'],
+           setupFiles: ['./vitest.setup.ts', './vitest.e2e.setup.ts'],
+           globals: true,
+           testTimeout: 30000,
+           pool: 'forks',
+         },
+       },
+       {
+         test: {
+           name: 'e2e-live',
+           root: '.',
+           include: ['test/assessor-live.e2e-spec.ts'],
+           setupFiles: ['./vitest.setup.ts'],
+           globals: true,
+           testTimeout: 30000,
+           pool: 'forks',
+         },
+       },
+       {
+         test: {
+           name: 'prod',
+           root: '.',
+           include: ['test/prod-tests/**/*.prod-spec.ts'],
+           setupFiles: ['./vitest.setup.ts'],
+           globals: true,
+           testTimeout: 600000,
+           pool: 'forks',
+         },
+       },
+     ]);
+     ```
+   - If workspace mode fails, fall back to separate `vitest.config.ts`, `vitest.e2e.config.ts`, etc.
+
+7. **Create `vitest.e2e.setup.ts`:**
+   - This file applies the LLM mock for E2E tests:
+     ```typescript
+     import { vi } from 'vitest';
+
+     process.env.E2E_MOCK_LLM = 'true';
+
+     vi.mock('@google/generative-ai', async () => {
+       const actual = await vi.importActual<
+         typeof import('@google/generative-ai')
+       >('@google/generative-ai');
+       return {
+         ...actual,
+         GoogleGenerativeAI: vi.fn().mockImplementation(() => ({
+           getGenerativeModel: () => ({
+             generateContent: async () => ({
+               response: {
+                 text: () =>
+                   JSON.stringify({
+                     completeness: { score: 3, reasoning: 'Mocked' },
+                     accuracy: { score: 3, reasoning: 'Mocked' },
+                     spag: { score: 3, reasoning: 'Mocked' },
+                   }),
+               },
+             }),
+           }),
+         })),
+       };
+     });
+     ```
+
+8. **Update `test/utils/app-lifecycle.ts`:**
+   - Remove lines 103–114 (the `if (testEnvironment.E2E_MOCK_LLM === 'true')` block that constructs `NODE_OPTIONS` with `--require`).
+   - No other changes needed in this file.
+
+9. **Delete `test/utils/llm-http-shim.cjs`:**
+   - Replaced by `vi.mock()` in `vitest.e2e.setup.ts`.
+
+10. **Update `package.json` scripts:**
+    - `"test": "vitest run"`
+    - `"test:watch": "vitest"`
+    - `"test:cov": "vitest run --coverage"`
+    - `"test:debug": "node --inspect-brk node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork"`
+    - `"test:e2e": "npm run test:e2e:mocked"`
+    - `"test:e2e:mocked": "npm run build && vitest run --project e2e"` (or `--config vitest.e2e.config.ts` if not using workspace)
+    - `"test:e2e:live": "npm run build && vitest run --project e2e-live"`
+    - `"test:prod": "npm run build && vitest run --project prod"`
+
+**Refactor:**
+
+- Verify `npm run test` invokes Vitest.
+- Verify `npm run build` still succeeds.
+
+**Section Checks:**
+
+- [ ] No Jest config files remain.
+- [ ] No Jest dependencies in `package.json`.
+- [ ] `vitest.workspace.ts` (or config files) exist.
+- [ ] `vitest.setup.ts` exists with environment setup.
+- [ ] `vitest.e2e.setup.ts` exists with LLM mock.
+- [ ] `test/utils/llm-http-shim.cjs` is deleted.
+- [ ] `test/utils/app-lifecycle.ts` no longer references `--require`.
+- [ ] `npm run test` invokes Vitest (tests will fail — that's expected until Section 3).
+
+---
+
+## Section 3: Test File Migration — Unit and Integration Tests
+
+**Objective:** Migrate all 36 `*.spec.ts` files in `src/` from Jest API to Vitest API.
+
+**Constraints:**
+
+- This is the largest section by file count. Work in batches to keep changes reviewable.
+- Each batch should be verified by running the tests.
+- Use the migration table in SPEC.md section 4.
+
+**Acceptance Criteria:**
+
+1. All 36 spec files use Vitest API (`vi.fn()`, `vi.mock()`, etc.) instead of Jest API.
+2. No `jest.*` calls remain in any `src/**/*.spec.ts` file.
+3. `npm run test` passes all unit and integration tests.
+4. Test coverage is maintained (no tests dropped or silently skipped).
+
+**Red-First Tests:**
+
+- The tests are already "red" from Section 2 (Jest APIs don't exist in Vitest). This section makes them "green".
+
+**Green — Implementation Steps (batched):**
+
+**Batch 1: Simple replacements (no `jest.mock()` or `jest.doMock()`)**
+Files that only use `jest.fn()`, `jest.spyOn()`, `jest.clearAllMocks()`:
+
+- Migrate `jest.fn()` → `vi.fn()`
+- Migrate `jest.spyOn()` → `vi.spyOn()`
+- Migrate `jest.clearAllMocks()` → `vi.clearAllMocks()`
+- Migrate `jest.Mock` type → `Mock` from `vitest`
+- Run `npm run test` to verify.
+
+**Batch 2: Files with `jest.mock()`**
+Files: `app.module.spec.ts`, `gemini.service.spec.ts`, `config.service.spec.ts`, `config.environment-example.spec.ts`, `table.prompt.spec.ts`, `image.prompt.spec`, `text.prompt.spec.ts`, `status.service.spec.ts`, `bootstrap.spec.ts`
+
+- Migrate `jest.mock()` → `vi.mock()`
+- Migrate `jest.requireActual()` → `vi.importActual()` (note: async)
+- Convert synchronous mock factories to async where `requireActual` is used.
+- Migrate `jest.mocked()` → `vi.mocked()` (in `config.service.spec.ts`, `config.environment-example.spec.ts`, `table.prompt.spec.ts`, `text.prompt.spec.ts`).
+- Remove `import { ... } from '@jest/globals'` in `bootstrap.spec.ts` (globals are enabled via config).
+- Update ESLint directive comments: `jest/expect-expect` → `vitest/expect-expect` (9 occurrences in `gemini.service.spec.ts`).
+- Note: `bootstrap.spec.ts` and `status.service.spec.ts` also use `jest.resetModules()` but NOT `jest.doMock()`. They use `jest.mock()` + `jest.resetModules()` — migrate `jest.resetModules()` → `vi.resetModules()` straightforwardly.
+- Run `npm run test` to verify.
+
+**Batch 3: Files with `jest.doMock()` + `jest.resetModules()`**
+Files: `main.spec.ts`, `testing-main.spec.ts` (ONLY these two files use `jest.doMock()`)
+
+- Apply the `doMock` migration pattern from SPEC.md section 4:
+  - Move `vi.mock()` to file scope (hoisted).
+  - Use mutable variables for mock implementations.
+  - Use `vi.resetModules()` in `beforeEach()`.
+- Run `npm run test` to verify.
+
+**Batch 4: Files with `jest.useFakeTimers()` and other edge cases**
+Files: `status.service.spec.ts` (uses `jest.useFakeTimers()` / `jest.useRealTimers()`)
+
+- Migrate `jest.useFakeTimers()` → `vi.useFakeTimers()`
+- Migrate `jest.useRealTimers()` → `vi.useRealTimers()`
+- Run `npm run test` to verify.
+
+**Refactor:**
+
+- Remove any unnecessary `vi.resetModules()` calls.
+- Ensure all mock types are correctly typed.
+- Run `npm run test:cov` to verify coverage is maintained.
+
+**Section Checks:**
+
+- [ ] All 36 spec files migrated.
+- [ ] Zero `jest.*` calls in `src/**/*.spec.ts`.
+- [ ] `npm run test` passes all unit/integration tests.
+- [ ] Coverage report shows no significant drop.
+
+---
+
+## Section 4: Test File Migration — E2E and Prod Tests
+
+**Objective:** Migrate all 10 test spec files in `test/` from Jest API to Vitest API.
+
+**Constraints:**
+
+- E2E tests require `npm run build` before running.
+- E2E tests spawn a child process — verify the ESM entry point works.
+- Prod tests run against the Docker image — may need separate handling.
+
+**Acceptance Criteria:**
+
+1. All 10 test spec files use Vitest API.
+2. No `jest.*` calls remain in `test/**/*.ts`.
+3. `npm run test:e2e:mocked` passes.
+4. `npm run test:e2e:live` passes (if API key available).
+5. `npm run test:prod` passes.
+
+**Red-First Tests:**
+
+- Tests are "red" from Section 2. This section makes them "green".
+
+**Green — Implementation Steps:**
+
+1. **Migrate E2E test files:**
+   - `test/assessor.e2e-spec.ts`
+   - `test/assessor-live.e2e-spec.ts`
+   - `test/auth.e2e-spec.ts`
+   - `test/logging.e2e-spec.ts`
+   - `test/main.e2e-spec.ts`
+   - `test/pentesting.e2e-spec.ts`
+   - `test/start-app.e2e-spec.ts` — uses `jest.setTimeout()`. Migrate to per-suite `testTimeout: 30000` in workspace config (already specified). Remove the `jest.setTimeout()` call.
+   - `test/throttler.e2e-spec.ts`
+   - `test/log-watcher.unit-spec.ts` — uses `jest.setTimeout()`. Migrate to per-suite `testTimeout` in workspace config. Remove the `jest.setTimeout()` call.
+   - `test/prod-tests/docker-image.production-spec.ts` — uses `jest.setTimeout()`. Migrate to per-suite `testTimeout: 600000` in workspace config (already specified). Remove the `jest.setTimeout()` call.
+
+   Apply the same Jest → Vitest API migration as Section 3.
+
+2. **Verify E2E mocked tests:**
+
+   ```bash
+   npm run build && npm run test:e2e:mocked
+   ```
+   - Verify the child process starts (`dist/src/testing-main.js` runs as ESM).
+   - Verify the LLM mock works (responses are deterministic).
+
+3. **Verify E2E live tests** (if API key available):
+
+   ```bash
+   npm run build && npm run test:e2e:live
+   ```
+
+4. **Verify prod tests:**
+   ```bash
+   npm run build && npm run test:prod
+   ```
+
+**Refactor:**
+
+- Ensure `app-lifecycle.ts` works correctly with ESM entry point.
+- Verify log file watching works under ESM.
+
+**Section Checks:**
+
+- [ ] All 10 test files migrated.
+- [ ] Zero `jest.*` calls in `test/**/*.ts`.
+- [ ] `npm run test:e2e:mocked` passes.
+- [ ] `npm run test:e2e:live` passes (or is skipped gracefully without API key).
+- [ ] `npm run test:prod` passes.
+
+---
+
+## Section 5: ESLint Configuration
+
+**Objective:** Update ESLint to remove Jest-specific workarounds and add Vitest support.
+
+**Constraints:**
+
+- No quality gates may be disabled (constraint C5).
+- Removed rules must be replaced with equivalents.
+
+**Acceptance Criteria:**
+
+1. `eslint-plugin-jest` is removed from `eslint.config.js`.
+2. Vitest globals are recognised by ESLint.
+3. `unicorn/prefer-module` and `unicorn/prefer-top-level-await` overrides for `main.ts` and `testing-main.ts` are removed.
+4. `**/*.cjs` ignore block is removed.
+5. `npm run lint` passes with no errors.
+
+**Red-First Tests:**
+
+- After removing Jest plugin and overrides, `npm run lint` will fail on files that still reference Jest patterns (if any remain from earlier sections). This is expected.
+
+**Green — Implementation Steps:**
+
+1. **Update `eslint.config.js`:**
+   - Remove `import jest from 'eslint-plugin-jest'`.
+   - Remove `jest` from plugins object.
+   - Remove `...globals.jest` from globals.
+   - Remove `...jest.configs.recommended.rules` from test file rules.
+   - Remove `unicorn/prefer-module: 'off'` and `unicorn/prefer-top-level-await: 'off'` overrides for `src/main.ts` and `src/testing-main.ts`.
+   - Remove `unicorn/prefer-uint8array-base64: 'off'` for `image-validation.pipe.ts` (CI now uses Node 24 which supports `Uint8Array.fromBase64()`).
+   - Remove `**/*.cjs` ignore block and rules.
+   - Add Vitest globals to the globals for test files: `vi: 'readonly'`, `describe: 'readonly'`, `it: 'readonly'`, `expect: 'readonly'`, `beforeEach: 'readonly'`, `afterEach: 'readonly'`, `beforeAll: 'readonly'`, `afterAll: 'readonly'`.
+   - Alternatively, install and configure `eslint-plugin-vitest`.
+
+2. **Run `npm run lint`:**
+   - Fix any remaining issues.
+
+**Refactor:**
+
+- Ensure all test files pass linting.
+- Verify no Jest-specific rules remain.
+
+**Section Checks:**
+
+- [ ] `npm run lint` passes.
+- [ ] No `eslint-plugin-jest` in `eslint.config.js`.
+- [ ] No `**/*.cjs` exceptions.
+- [ ] No `unicorn/prefer-module` overrides for entry-point files.
+
+---
+
+## Section 6: CI/CD and Scripts
+
+**Objective:** Update CI workflow and npm scripts for Vitest.
+
+**Constraints:**
+
+- CI must continue to run lint, unit tests, and E2E tests.
+- JUnit reports must still be generated for GitHub test reporting.
+
+**Acceptance Criteria:**
+
+1. `.github/workflows/ci.yml` references Vitest commands and report paths.
+2. `npm run test:cov` produces coverage output.
+3. JUnit XML reports are generated at `./junit/vitest-junit.xml`.
+4. `verify:assessor` script works under ESM.
+
+**Green — Implementation Steps:**
+
+1. **Update `.github/workflows/ci.yml`:**
+   - Line 19, 41, 69: Change `node-version: '22'` → `node-version: '24'` (align with Dockerfile's `node:24-alpine`).
+   - Line 47: Change `npm test -- --verbose --coverage` → `npm run test:cov`.
+   - Line 53: Change `report_paths: './junit/jest-junit.xml'` → `report_paths: './junit/vitest-junit.xml'`.
+   - Line 81: Change `npm run test:e2e -- --verbose` → `npm run test:e2e`.
+   - Line 87: Change `report_paths: './junit/jest-junit.xml'` → `report_paths: './junit/vitest-junit.xml'`.
+
+2. **Configure Vitest JUnit reporter:**
+   - Add to Vitest config: `reporters: ['default', 'junit']`, `outputFile: './junit/vitest-junit.xml'`.
+
+3. **Update `verify:assessor` script:**
+   - Change from `ts-node scripts/verify-assessor.ts` → `tsx scripts/verify-assessor.ts`.
+   - Install `tsx` if not already present: `npm install --save-dev tsx`.
+
+4. **Verify CI locally:**
+   - Run `npm run lint`.
+   - Run `npm run test:cov`.
+   - Run `npm run test:e2e`.
+
+**Section Checks:**
+
+- [ ] `ci.yml` updated.
+- [ ] JUnit reports generated at correct path.
+- [ ] `verify:assessor` works.
+- [ ] All npm scripts work.
+
+---
+
+## Section 7: Documentation Updates
+
+**Objective:** Update all documentation files that reference Jest.
+
+**Constraints:**
+
+- British English compliance (constraint C6).
+- Documentation must accurately reflect the new tooling.
+
+**Acceptance Criteria:**
+
+1. All 22 documentation files listed in SPEC.md section 12 are updated.
+2. No references to `jest`, `Jest`, `jest.config.js`, `jest-e2e.*.config.cjs`, `jest.fn()`, `jest.Mock`, etc. remain in documentation.
+3. Code examples use Vitest API (`vi.fn()`, `vi.mock()`, etc.).
+
+**Green — Implementation Steps:**
+
+1. **Update each file** (see SPEC.md section 12 for the full list):
+   - Replace "Jest" with "Vitest" in prose.
+   - Replace `jest.fn()` with `vi.fn()` in code examples.
+   - Replace `jest.Mock` with `Mock` (from `vitest`) in code examples.
+   - Update config file references (`jest.config.js` → `vitest.workspace.ts`, etc.).
+   - Update command references (`npm test` → same, but underlying tool is Vitest).
+   - Remove references to `llm-http-shim.cjs` and `--require` pattern.
+   - Update testing guides to describe Vitest patterns.
+
+2. **Update `AGENTS.md`:**
+   - Tech stack: "Vitest for unit, integration, and E2E tests."
+   - File path resolution: Remove "and Jest test environments" from `getCurrentDirname()` description.
+
+3. **Update `.opencode/agents/*.md` and `.github/agents/*.md`:**
+   - Update agent descriptions and routing rules to reference Vitest.
+
+**Section Checks:**
+
+- [ ] All 22 files updated.
+- [ ] `grep -r "jest" docs/ AGENTS.md README.md` returns no results (excluding SPEC.md and ACTION_PLAN.md).
+- [ ] Code examples use Vitest API.
+
+---
+
+## Section 8: Final Cleanup and Regression
+
+**Objective:** Verify all state rules are met. Remove any remaining Jest artifacts. Run full regression.
+
+**Constraints:**
+
+- All state rules S1–S7 must pass.
+- All success criteria from SPEC.md must be met.
+
+**Acceptance Criteria:**
+
+1. Zero `.cjs` files in the repository (excluding `node_modules`).
+2. Zero `require()` or `module.exports` in any source, test, or config file.
+3. Zero `jest.*` calls in any file.
+4. `package.json` has `"type": "module"` and no Jest dependencies.
+5. `tsconfig.json` emits ESM.
+6. All tests pass: `npm run test`, `npm run test:e2e:mocked`, `npm run test:e2e:live`, `npm run test:prod`.
+7. `npm run lint` passes.
+8. `npm run build` succeeds.
+9. `node dist/src/main.js` starts the application.
+
+**Green — Verification Steps:**
+
+1. **Search for remaining artifacts:**
+
+   ```bash
+   # No .cjs files
+   find . -name '*.cjs' -not -path './node_modules/*'
+
+   # No require() or module.exports
+   grep -r 'require(' src/ test/ scripts/ --include='*.ts' --include='*.js'
+   grep -r 'module.exports' src/ test/ scripts/ --include='*.ts' --include='*.js'
+
+   # No jest.* calls
+   grep -r 'jest\.' src/ test/ --include='*.ts'
+   ```
+
+2. **Run full test suite:**
+
+   ```bash
+   npm run build
+   npm run test
+   npm run test:e2e:mocked
+   npm run test:e2e:live  # If API key available
+   npm run test:prod
+   npm run lint
+   ```
+
+3. **Verify production startup:**
+
+   ```bash
+   node dist/src/main.js
+   ```
+
+4. **Verify coverage:**
+
+   ```bash
+   npm run test:cov
+   ```
+   - Verify coverage output format is compatible with SonarQube (check `sonar-project.properties` for coverage path configuration).
+
+5. **Verify `dev:delegate` script:**
+
+   ```bash
+   npm run dev:delegate -- --help  # Or any simple invocation
+   ```
+   - This script uses `ts-node --esm`. Verify it still works after `tsconfig.json` changes.
+
+6. **Verify `health-check.js`:**
+   - Confirm the converted ESM health-check script parses correctly (no broken comment syntax from the original file).
+
+**Refactor:**
+
+- Fix any remaining issues found during verification.
+- Remove any dead code or unused imports discovered during migration.
+
+**Section Checks:**
+
+- [ ] All state rules S1–S7 pass.
+- [ ] All success criteria met.
+- [ ] No remaining Jest artifacts.
+- [ ] Full regression passes.
+
+---
+
+## Summary of Section Ordering
+
+| Section | Objective                            | Depends On                                     |
+| ------- | ------------------------------------ | ---------------------------------------------- |
+| 0       | Validation and de-risking            | Nothing                                        |
+| 1       | TypeScript and package configuration | Section 0                                      |
+| 2       | Test runner infrastructure           | Section 1                                      |
+| 3       | Unit/integration test migration      | Section 2                                      |
+| 4       | E2E and prod test migration          | Section 2 (can run in parallel with Section 3) |
+| 5       | ESLint configuration                 | Section 3, Section 4                           |
+| 6       | CI/CD and scripts                    | Section 5                                      |
+| 7       | Documentation updates                | Section 5                                      |
+| 8       | Final cleanup and regression         | All previous                                   |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](https://www.c
 
 ### Reporting Bugs
 
-If you find a bug, please open an issue on our [GitHub Issues page](https://github.com/h-arnold/Assessment Bot LLM Service/issues). When reporting a bug, please include:
+If you find a bug, please open an issue on our [GitHub Issues page](https://github.com/h-arnold/AssessmentBot-LLM-Service/issues). When reporting a bug, please include:
 
 - A clear and concise description of the bug.
 - Steps to reproduce the behavior.
@@ -33,7 +33,7 @@ If you find a bug, please open an issue on our [GitHub Issues page](https://gith
 
 ### Suggesting Enhancements
 
-For feature requests or enhancements, please open an issue on our [GitHub Issues page](https://github.com/h-arnold/Assessment Bot LLM Service/issues). Describe the enhancement, why it would be useful, and any potential solutions.
+For feature requests or enhancements, please open an issue on our [GitHub Issues page](https://github.com/h-arnold/AssessmentBot-LLM-Service/issues). Describe the enhancement, why it would be useful, and any potential solutions.
 
 ### Pull Request Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](https://www.c
 
 ### Reporting Bugs
 
-If you find a bug, please open an issue on our [GitHub Issues page](https://github.com/h-arnold/AssessmentBot-Backend/issues). When reporting a bug, please include:
+If you find a bug, please open an issue on our [GitHub Issues page](https://github.com/h-arnold/Assessment Bot LLM Service/issues). When reporting a bug, please include:
 
 - A clear and concise description of the bug.
 - Steps to reproduce the behavior.
@@ -33,7 +33,7 @@ If you find a bug, please open an issue on our [GitHub Issues page](https://gith
 
 ### Suggesting Enhancements
 
-For feature requests or enhancements, please open an issue on our [GitHub Issues page](https://github.com/h-arnold/AssessmentBot-Backend/issues). Describe the enhancement, why it would be useful, and any potential solutions.
+For feature requests or enhancements, please open an issue on our [GitHub Issues page](https://github.com/h-arnold/Assessment Bot LLM Service/issues). Describe the enhancement, why it would be useful, and any potential solutions.
 
 ### Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Assessment Bot - Backend
+# Assessment Bot - LLM Service
 
-![CI - Unit & E2E Tests](https://github.com/h-arnold/AssessmentBot-Backend/actions/workflows/ci.yml/badge.svg)
-![CodeQL](https://github.com/h-arnold/AssessmentBot-Backend/actions/workflows/codeql.yml/badge.svg)
-![SonarQube](https://github.com/h-arnold/AssessmentBot-Backend/actions/workflows/sonarqube.yml/badge.svg)
+![CI - Unit & E2E Tests](https://github.com/h-arnold/Assessment Bot LLM Service/actions/workflows/ci.yml/badge.svg)
+![CodeQL](https://github.com/h-arnold/Assessment Bot LLM Service/actions/workflows/codeql.yml/badge.svg)
+![SonarQube](https://github.com/h-arnold/Assessment Bot LLM Service/actions/workflows/sonarqube.yml/badge.svg)
 
 ## Introduction
 
@@ -38,8 +38,8 @@ This method starts the application along with a Caddy reverse proxy and Fail2ban
 1.  **Clone the repository**:
 
     ```bash
-    git clone https://github.com/h-arnold/AssessmentBot-Backend.git
-    cd AssessmentBot-Backend
+    git clone https://github.com/h-arnold/Assessment Bot LLM Service.git
+    cd Assessment Bot LLM Service
     ```
 
 2.  **Set up environment variables**:
@@ -82,8 +82,8 @@ Common flags:
 1.  **Clone and install**:
 
     ```bash
-    git clone https://github.com/h-arnold/AssessmentBot-Backend.git
-    cd AssessmentBot-Backend
+    git clone https://github.com/h-arnold/Assessment Bot LLM Service.git
+    cd Assessment Bot LLM Service
     npm install
     ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Assessment Bot - LLM Service
 
-![CI - Unit & E2E Tests](https://github.com/h-arnold/Assessment Bot LLM Service/actions/workflows/ci.yml/badge.svg)
-![CodeQL](https://github.com/h-arnold/Assessment Bot LLM Service/actions/workflows/codeql.yml/badge.svg)
-![SonarQube](https://github.com/h-arnold/Assessment Bot LLM Service/actions/workflows/sonarqube.yml/badge.svg)
+![CI - Unit & E2E Tests](https://github.com/h-arnold/AssessmentBot-LLM-Service/actions/workflows/ci.yml/badge.svg)
+![CodeQL](https://github.com/h-arnold/AssessmentBot-LLM-Service/actions/workflows/codeql.yml/badge.svg)
+![SonarQube](https://github.com/h-arnold/AssessmentBot-LLM-Service/actions/workflows/sonarqube.yml/badge.svg)
 
 ## Introduction
 
@@ -38,8 +38,8 @@ This method starts the application along with a Caddy reverse proxy and Fail2ban
 1.  **Clone the repository**:
 
     ```bash
-    git clone https://github.com/h-arnold/Assessment Bot LLM Service.git
-    cd Assessment Bot LLM Service
+    git clone https://github.com/h-arnold/AssessmentBot-LLM-Service.git
+    cd AssessmentBot-LLM-Service
     ```
 
 2.  **Set up environment variables**:
@@ -82,8 +82,8 @@ Common flags:
 1.  **Clone and install**:
 
     ```bash
-    git clone https://github.com/h-arnold/Assessment Bot LLM Service.git
-    cd Assessment Bot LLM Service
+    git clone https://github.com/h-arnold/AssessmentBot-LLM-Service.git
+    cd AssessmentBot-LLM-Service
     npm install
     ```
 

--- a/RESEARCH_FINDINGS.md
+++ b/RESEARCH_FINDINGS.md
@@ -1,0 +1,142 @@
+# Research Findings Summary
+
+## Date: 2026-07-04
+
+## Purpose
+
+Research critical assumptions before proceeding with Jest → Vitest migration and full ESM adoption.
+
+---
+
+## 1. CI Node Version Update
+
+**Decision:** Update CI from Node 22 to Node 24
+
+**Rationale:**
+
+- Dockerfile already uses `node:24-alpine`
+- Eliminates technical debt from keeping `unicorn/prefer-uint8array-base64` ESLint override
+- Node 24 supports `Uint8Array.fromBase64()` natively
+- Aligns CI environment with production environment
+
+**Impact:**
+
+- Remove `unicorn/prefer-uint8array-base64: 'off'` override from `eslint.config.js`
+- Update `.github/workflows/ci.yml` lines 19, 41, 69: `node-version: '22'` → `node-version: '24'`
+
+---
+
+## 2. NestJS TestingModule + Vitest Compatibility
+
+**Research Source:** GitHub issue nestjs/nest#17047 (opened 2026-05-28, closed 2026-06-03)
+
+**Finding:**
+
+- **Critical Issue:** Vitest with SWC/esbuild fails to emit decorator metadata
+- **Root Cause:** SWC and esbuild don't support `emitDecoratorMetadata` TypeScript compiler option
+- **Symptom:** `TestingModule` dependency injection fails — injected services become `undefined`
+- **Affected Scenarios:** Constructor injection without explicit `@Inject()` decorators
+
+**Why This Matters for Our Project:**
+
+- Our project uses `tsc` (TypeScript compiler) which DOES emit decorator metadata correctly
+- However, Vitest's default transformer may override `tsc` output
+- If Vitest uses SWC/esbuild internally, we'll hit this issue
+
+**Mitigation Strategy (Phase 0 Validation):**
+
+1. Test `TestingModule` with constructor injection (no `@Inject()` decorators)
+2. If DI fails, two options:
+   - **Option A:** Configure Vitest to use `tsc` as transformer (preserves metadata)
+   - **Option B:** Add explicit `@Inject()` decorators to all constructor parameters (significant code change)
+
+**Risk Level:** HIGH — Could require adding `@Inject()` to 50+ constructor parameters
+
+**Status:** Requires validation in Phase 0 before proceeding
+
+---
+
+## 3. reflect-metadata ESM Compatibility
+
+**Research Source:** microsoft/reflect-metadata repository issues, Node.js ESM documentation
+
+**Finding:**
+
+- `reflect-metadata` is fully ESM-compatible
+- No ESM-specific issues found in the repository
+- Key requirement: Must be imported BEFORE any decorated classes are loaded
+
+**ESM Import Order:**
+
+- ESM has deterministic import order (static analysis)
+- Importing `reflect-metadata` first in setup files or entry points works correctly
+- No special handling needed beyond ensuring it's the first import
+
+**Implementation:**
+
+- Add `import 'reflect-metadata'` as first line in:
+  - `src/main.ts`
+  - `src/testing-main.ts`
+  - `vitest.setup.ts`
+  - `vitest.e2e.setup.ts`
+
+**Risk Level:** LOW — Well-understood, straightforward implementation
+
+---
+
+## 4. Updated Documentation
+
+### SPEC.md Updates
+
+- **Section 8 (CI/CD):** Added Node version update from 22 → 24
+- **Section 7 (ESLint):** Changed `unicorn/prefer-uint8array-base64` from "keep" to "remove"
+- **Open Questions:**
+  - Q1 updated with research findings on TestingModule compatibility
+  - Q5 added: reflect-metadata ESM compatibility (resolved: yes)
+- **Risks:**
+  - R6 updated: reflect-metadata is ESM-compatible, just needs correct import order
+  - R8 added: Vitest transformer decorator metadata issue (HIGH risk)
+
+### ACTION_PLAN.md Updates
+
+- **Section 0 (Phase 0):**
+  - Added acceptance criterion #6: Vitest transformer preserves decorator metadata
+  - Enhanced validation step #2 with detailed TestingModule DI test
+  - Updated blockers section with TestingModule failure scenarios
+- **Section 5 (ESLint):** Updated to remove `unicorn/prefer-uint8array-base64` override
+- **Section 6 (CI/CD):** Added Node version update step
+
+---
+
+## 5. Critical Path Items
+
+### Must Validate in Phase 0
+
+1. ✅ NestJS ESM compilation with `emitDecoratorMetadata`
+2. ⚠️ **TestingModule DI with Vitest (CRITICAL)**
+3. ✅ `nest build` ESM output
+4. ✅ `reflect-metadata` import ordering
+
+### Potential Blockers
+
+- If Vitest transformer doesn't preserve decorator metadata:
+  - **Option A:** Configure Vitest to use `tsc` (preferred)
+  - **Option B:** Add `@Inject()` decorators (fallback, requires user approval)
+
+---
+
+## 6. Next Steps
+
+1. **Proceed with Phase 0 validation** — focus on TestingModule DI test
+2. **Document TestingModule test result** before proceeding to Section 1
+3. **If DI fails:** Present options to user before continuing
+4. **If DI passes:** Continue with migration as planned
+
+---
+
+## 7. References
+
+- GitHub Issue: https://github.com/nestjs/nest/issues/17047
+- NestJS Vitest Recipe: https://docs.nestjs.com/recipes/vitest
+- reflect-metadata: https://github.com/microsoft/reflect-metadata
+- Node.js ESM: https://nodejs.org/api/esm.html

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,398 @@
+# SPEC: Eliminate CommonJS Module Exports — Full ESM Migration
+
+## Purpose
+
+Remove the requirement for CommonJS module output from the codebase. The codebase currently writes ESM syntax (`import`/`export`) in all source files but compiles to CommonJS (`"module": "CommonJS"` in `tsconfig.json`) solely because Jest's ESM support is incomplete. This migration switches the test runner from Jest to Vitest (which supports ESM natively), enabling the entire project — source, tests, and production build output — to use pure ESM.
+
+## Background
+
+The ESLint configuration already documents this intent (`eslint.config.js`, lines 237–248):
+
+> _"Jest runs inside a CommonJS environment (tsconfig.module = CommonJS) that lacks both top-level await support and the Uint8Array.fromBase64() method... These overrides will be removed when the project migrates from Jest to ViTest (which supports ESM natively), eliminating both constraints in a single change."_
+
+The source code is already pure ESM syntax. Zero `require()`, `module.exports`, `__dirname`, or `__filename` calls exist in any `.ts` source file. The CommonJS requirement is entirely in configuration and test infrastructure.
+
+## Decisions
+
+| #   | Decision                                                                         | Rationale                                                                                                                                                                                      |
+| --- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Full ESM everywhere — production build output AND tests                          | Eliminates all CommonJS. `package.json` gets `"type": "module"`. `tsconfig.json` emits ESM. `node dist/src/main.js` runs as ESM.                                                               |
+| D2  | All test types migrate to Vitest (unit, integration, E2E, prod)                  | Single test runner, single configuration, consistent mocking APIs. Removes all `.cjs` Jest config files.                                                                                       |
+| D3  | Vitest replaces Jest entirely — no hybrid approach                               | Avoids maintaining two test runners and two sets of configuration.                                                                                                                             |
+| D4  | `tsconfig.json` uses `"module": "NodeNext"` and `"moduleResolution": "NodeNext"` | The most correct ESM configuration for Node.js. Enforces explicit file extensions in imports where required by Node's ESM resolver.                                                            |
+| D5  | NestJS v11 ESM compatibility is validated early                                  | NestJS v11.1.27 can run ESM output but the ecosystem is primarily CJS-tested. Early validation de-risks the migration.                                                                         |
+| D6  | Vitest globals enabled (`globals: true` in config)                               | Avoids adding `import { describe, it, expect, vi } from 'vitest'` to all 46 test files. The `describe`/`it`/`expect`/`beforeEach` API is identical to Jest's globals, so this minimises churn. |
+| D7  | Vitest workspace mode for multi-suite configuration                              | A single `vitest.workspace.ts` manages unit, E2E, live, and prod test suites. Cleaner than maintaining 4 separate config files.                                                                |
+| D8  | E2E LLM mocking via `vi.mock()` in Vitest setup file                             | Replaces the `llm-http-shim.cjs` + `--require` pattern. The mock is applied in the E2E Vitest setup file using `vi.mock('@google/generative-ai')`, which works natively with ESM.              |
+
+## Scope
+
+### In scope
+
+1. **TypeScript configuration** — Change `tsconfig.json` to emit ESM. Update `tsconfig.build.json` and `tsconfig.test.json` accordingly.
+2. **Package configuration** — Add `"type": "module"` to `package.json`. Remove Jest dependencies. Add Vitest dependencies.
+3. **Test runner migration** — Replace all Jest configuration (1 `jest.config.js` + 4 `.cjs` configs) with a Vitest workspace configuration. Convert all 46 test files (36 `*.spec.ts` in `src/` + 10 test specs in `test/`) from Jest API to Vitest API.
+4. **Entry-point detection** — Replace `require.main === module` in `main.ts` and `testing-main.ts` with ESM-compatible pattern.
+5. **Utility scripts** — Convert `health-check.js` to ESM. Replace `llm-http-shim.cjs` with Vitest-native mocking.
+6. **ESLint configuration** — Remove Jest-specific workarounds. Replace `eslint-plugin-jest` with Vitest equivalent. Remove `unicorn/prefer-module` and `unicorn/prefer-top-level-await` overrides that exist solely for Jest compatibility.
+7. **npm scripts** — Update all test-related scripts to use Vitest. Update `test:debug` to remove `-r ts-node/register` (CJS hook).
+8. **CI/CD configuration** — Update any CI references from Jest to Vitest (coverage reporters, JUnit output).
+9. **Documentation** — Update `AGENTS.md`, `docs/development/workflow.md`, and other docs that reference Jest.
+
+### Out of scope
+
+- Changing the NestJS framework version or upgrading NestJS itself.
+- Migrating from `ts-node` to `tsx` for script execution (though `ts-node` ESM hooks may need updating).
+- Adding new features or refactoring business logic.
+- Changing the Dockerfile base image or build pipeline structure.
+
+## Constraints
+
+| #   | Constraint                                                  | Detail                                                                                                                                                                                                |
+| --- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1  | All existing tests must pass after migration                | No test may be dropped or silently skipped. Coverage must be maintained.                                                                                                                              |
+| C2  | NestJS decorator metadata must continue working             | `emitDecoratorMetadata: true` and `experimentalDecorators: true` must remain functional under ESM output.                                                                                             |
+| C3  | Production startup must work identically                    | `node dist/src/main.js` must start the server. The `isRunningDirectly()` check must work under ESM.                                                                                                   |
+| C4  | E2E tests must still spawn the built app as a child process | The `app-lifecycle.ts` pattern of spawning `dist/src/testing-main.js` must continue to work.                                                                                                          |
+| C5  | No quality gate may be disabled                             | Per `AGENTS.md`: "Do not disable or override any quality gate (including linter rules) without explicit authorisation." ESLint rules removed must be replaced with equivalents, not silently dropped. |
+| C6  | British English compliance                                  | All new code, comments, and documentation must use British English.                                                                                                                                   |
+| C7  | `supertest` E2E pattern preserved                           | E2E tests use `supertest` for HTTP assertions. This library works with Vitest.                                                                                                                        |
+
+## Contracts and Changes
+
+### 1. TypeScript Configuration (`tsconfig.json`)
+
+**Current:**
+
+```json
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "jest"]
+  }
+}
+```
+
+**Target:**
+
+```json
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"]
+  }
+}
+```
+
+Note: If Vitest globals are enabled (decision D6), test files will not need explicit imports. However, TypeScript still needs type information for `describe`, `it`, `expect`, `vi`, etc. This is handled by Vitest's type augmentation — either add `"vitest/globals"` to the `types` array, or ensure the Vitest config's `globals: true` automatically augments the global types (which it does when `/// <reference types="vitest/globals" />` is included or when `@types/vitest` is resolved). The implementation agent should verify which approach works with the chosen Vitest version.
+
+- `tsconfig.build.json` inherits and excludes test files — no structural change needed.
+- `tsconfig.test.json` — **Delete this file.** It exists solely to override `module` to `ES2022` for Jest's ESM mode and to configure `ts-node.esm`. Neither is needed after migration. The `ts-node` ESM configuration is no longer relevant since `ts-node` is only used for the `dev:delegate` and `verify:assessor` scripts, which already pass `--esm` explicitly or will be updated.
+
+### 2. Package Configuration (`package.json`)
+
+**Add:**
+
+```json
+{
+  "type": "module"
+}
+```
+
+**Remove dependencies:**
+
+- `jest`, `@types/jest`, `ts-jest`, `jest-junit`, `eslint-plugin-jest`
+
+**Add dependencies:**
+
+- `vitest` (test runner)
+- `@vitest/coverage-v8` (coverage provider)
+- `eslint-plugin-vitest` (or equivalent lint rules)
+
+**Update scripts:**
+
+| Current                                                                                                                | Target                                                                                                        |
+| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `"test": "jest"`                                                                                                       | `"test": "vitest run"`                                                                                        |
+| `"test:watch": "jest --watch"`                                                                                         | `"test:watch": "vitest"`                                                                                      |
+| `"test:cov": "jest --coverage"`                                                                                        | `"test:cov": "vitest run --coverage"`                                                                         |
+| `"test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"` | `"test:debug": "node --inspect-brk node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork"` |
+| `"test:e2e": "npm run test:e2e:mocked"`                                                                                | `"test:e2e": "vitest run --config vitest.e2e.config.ts"`                                                      |
+| `"test:e2e:mocked": "npm run build && jest --config ./jest-e2e.mocked.config.cjs --runInBand"`                         | `"test:e2e:mocked": "npm run build && vitest run --config vitest.e2e.config.ts"`                              |
+| `"test:e2e:live": "npm run build && jest --config ./jest-e2e.live.config.cjs --runInBand"`                             | `"test:e2e:live": "npm run build && vitest run --config vitest.e2e.live.config.ts"`                           |
+| `"test:prod": "npm run build && jest --config ./jest-prod.config.cjs --runInBand"`                                     | `"test:prod": "npm run build && vitest run --config vitest.prod.config.ts"`                                   |
+
+### 3. Test Runner Configuration
+
+**Remove files:**
+
+- `jest.config.js`
+- `jest-e2e.mocked.config.cjs`
+- `jest-e2e.live.config.cjs`
+- `jest-e2e.config.cjs` (appears to be dead code — not referenced by any npm script)
+- `jest-prod.config.cjs`
+- `jest.setup.ts` (replace with Vitest setup)
+- `test/jest.e2e.mocked.setup.ts` (logic moves into Vitest E2E config/workspace)
+- `test/jest.e2e.live.setup.ts` (logic moves into Vitest E2E config/workspace)
+- `test/utils/llm-http-shim.cjs` (replaced by Vitest `vi.mock()` — see section 6)
+
+**Create files:**
+
+- `vitest.workspace.ts` — Workspace definition managing all test suites (unit, E2E, live, prod)
+- `vitest.setup.ts` — Global setup for unit/integration tests (replaces `jest.setup.ts`)
+- `vitest.e2e.setup.ts` — E2E-specific setup (applies LLM mock via `vi.mock()`)
+
+Alternatively, if workspace mode proves problematic, fall back to separate config files:
+
+- `vitest.config.ts` — Unit and integration tests
+- `vitest.e2e.config.ts` — E2E tests (mocked)
+- `vitest.e2e.live.config.ts` — Live E2E tests
+- `vitest.prod.config.ts` — Production environment tests
+
+### 4. Jest API → Vitest API Migration
+
+All 46 test files (36 `*.spec.ts` in `src/` + 10 test specs in `test/`) require translation. The following table covers all Jest APIs found in the codebase:
+
+**Runtime APIs:**
+
+| Jest API               | Files Using It                                                                                   | Vitest Equivalent                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `jest.fn()`            | ~18 files, ~115 calls                                                                            | `vi.fn()`                                                               |
+| `jest.mock()`          | 9 files, 13 calls                                                                                | `vi.mock()`                                                             |
+| `jest.doMock()`        | 2 files (`main.spec.ts`, `testing-main.spec.ts`), 4 calls                                        | See "doMock migration pattern" below                                    |
+| `jest.spyOn()`         | 4 files, 6 calls                                                                                 | `vi.spyOn()`                                                            |
+| `jest.requireActual()` | 1 file (`gemini.service.spec.ts`), 1 call                                                        | `vi.importActual()` (async)                                             |
+| `jest.resetModules()`  | 5 files, 8 calls                                                                                 | `vi.resetModules()`                                                     |
+| `jest.clearAllMocks()` | 10 files, 12 calls                                                                               | `vi.clearAllMocks()`                                                    |
+| `jest.setTimeout()`    | 3 files (`log-watcher.unit-spec.ts`, `start-app.e2e-spec.ts`, `docker-image.production-spec.ts`) | `testTimeout` in Vitest config, or `vi.setConfig({ testTimeout: ... })` |
+| `jest.mocked()`        | Used for type casting                                                                            | `vi.mocked()`                                                           |
+
+**Type APIs:**
+
+| Jest Type        | Approximate Occurrences          | Vitest Equivalent                            |
+| ---------------- | -------------------------------- | -------------------------------------------- |
+| `jest.Mock`      | ~56 occurrences across ~12 files | `Mock` (imported from `vitest`) or `vi.Mock` |
+| `jest.Mocked<T>` | 2 occurrences in docs            | `Mocked<T>` (imported from `vitest`)         |
+
+**Test structure APIs (no change needed):**
+
+- `describe`, `it`, `expect`, `beforeEach`, `afterEach`, `beforeAll`, `afterAll` — identical API.
+- `expect.hasAssertions()` — supported natively by Vitest.
+
+**ESLint directive changes:**
+
+- Comments referencing the `jest/expect-expect` rule (9 occurrences in `gemini.service.spec.ts`) must be updated to reference `vitest/expect-expect` instead.
+
+**`@jest/globals` import:**
+
+- `bootstrap.spec.ts` imports from `@jest/globals` — change to `import { ... } from 'vitest'` (or remove if globals are enabled).
+
+#### `jest.doMock()` migration pattern
+
+The `jest.doMock()` + `jest.resetModules()` pattern (used in `main.spec.ts`, `testing-main.spec.ts`, `app.module.spec.ts`, `status.service.spec.ts`, `bootstrap.spec.ts`) is the trickiest migration. Jest's `doMock()` registers a mock that takes effect on the next `require()`, and `resetModules()` clears the module cache so subsequent `import()` calls re-execute the module with the new mock.
+
+In Vitest, `vi.mock()` is always hoisted to the top of the file and cannot be called conditionally inside `beforeEach()`. The equivalent pattern uses `vi.mock()` with a factory that reads from a mutable variable, combined with `vi.resetModules()`:
+
+```typescript
+// Before (Jest):
+beforeEach(() => {
+  jest.resetModules();
+  jest.doMock('./bootstrap', () => ({ bootstrap: mockBootstrap }));
+});
+it('should call bootstrap', async () => {
+  const { start } = await import('./main');
+  await start();
+  expect(mockBootstrap).toHaveBeenCalled();
+});
+
+// After (Vitest):
+let mockBootstrap: () => void;
+vi.mock('./bootstrap', () => ({ bootstrap: mockBootstrap }));
+
+beforeEach(() => {
+  vi.resetModules();
+  mockBootstrap = vi.fn();
+});
+it('should call bootstrap', async () => {
+  const { start } = await import('./main');
+  await start();
+  expect(mockBootstrap).toHaveBeenCalled();
+});
+```
+
+**Key behavioural difference:** Vitest's `vi.mock()` is hoisted to the top of the file automatically (like Jest's), but `vi.mock()` with factory functions in ESM mode uses `vi.importActual()` (async) instead of `jest.requireActual()` (sync). This requires converting synchronous mock factories to async where `requireActual` is used.
+
+### 5. Entry-Point Detection (`main.ts`, `testing-main.ts`)
+
+**Current (CommonJS):**
+
+```typescript
+function isRunningDirectly(): boolean {
+  return (
+    typeof require !== 'undefined' &&
+    require.main === module &&
+    !process.env.JEST_WORKER_ID
+  );
+}
+```
+
+**Target (ESM):**
+
+```typescript
+import { pathToFileURL } from 'node:url';
+
+function isRunningDirectly(): boolean {
+  return (
+    process.argv[1] != null &&
+    import.meta.url === pathToFileURL(process.argv[1]).href
+  );
+}
+```
+
+The `JEST_WORKER_ID` check is no longer needed since Vitest does not set this environment variable. The `process.argv[1] != null` guard prevents a crash when the script is loaded via `node -e` or in a REPL where `process.argv[1]` is `undefined`.
+
+### 6. Utility Scripts
+
+**`scripts/health-check.js`:**
+Convert from `require('node:http')` to `import http from 'node:http'`. Since `package.json` will have `"type": "module"`, the `.js` extension will be treated as ESM.
+
+**`test/utils/llm-http-shim.cjs`:**
+This file is loaded via `--require` (CJS-only) to monkey-patch the Gemini SDK for mocked E2E tests. With Vitest, the mocking strategy changes entirely (see decision D8):
+
+- The `.cjs` file is **deleted**.
+- The `--require` approach is removed from `test/utils/app-lifecycle.ts` (lines 103–114). The entire `if (testEnvironment.E2E_MOCK_LLM === 'true')` block that constructs `NODE_OPTIONS` with `--require "${shimPath}"` must be removed. No other changes are required in `app-lifecycle.ts`.
+- E2E LLM mocking is instead handled by `vi.mock('@google/generative-ai')` in the Vitest E2E setup file (`vitest.e2e.setup.ts`). This mock intercepts the `GoogleGenerativeAI` class and returns deterministic responses, replacing the prototype monkey-patch.
+
+### 7. ESLint Configuration (`eslint.config.js`)
+
+**Remove:**
+
+- `eslint-plugin-jest` import and plugin registration
+- Jest globals (`...globals.jest`)
+- All Jest-specific rule blocks (`jest.configs.recommended.rules`)
+- `unicorn/prefer-module: 'off'` overrides for `src/main.ts` and `src/testing-main.ts` (no longer needed — ESM natively supports these patterns)
+- `unicorn/prefer-top-level-await: 'off'` overrides for the same files (ESM supports top-level await)
+- `unicorn/prefer-uint8array-base64: 'off'` override for `image-validation.pipe.ts` — **Remove this override.** CI will be updated to Node.js 24 (matching the Dockerfile), which supports `Uint8Array.fromBase64()`. The override was only needed because CI previously used Node.js 22.
+- `**/*.cjs` ignore block (no more `.cjs` files)
+
+**Add:**
+
+- `eslint-plugin-vitest` (or configure globals for Vitest: `vi`, `describe`, `it`, `expect`, etc.)
+- Vitest-specific rule configuration for test files
+
+### 8. CI/CD Configuration (`.github/workflows/ci.yml`)
+
+**Changes required:**
+
+| Line       | Current                                  | Target                                                                                 |
+| ---------- | ---------------------------------------- | -------------------------------------------------------------------------------------- |
+| 19, 41, 69 | `node-version: '22'`                     | `node-version: '24'` (align with Dockerfile's `node:24-alpine`)                        |
+| 47         | `npm test -- --verbose --coverage`       | `npm run test:cov` (Vitest coverage uses different flags)                              |
+| 53         | `report_paths: './junit/jest-junit.xml'` | `report_paths: './junit/vitest-junit.xml'` (or whatever Vitest JUnit reporter outputs) |
+| 81         | `npm run test:e2e -- --verbose`          | `npm run test:e2e`                                                                     |
+| 87         | `report_paths: './junit/jest-junit.xml'` | `report_paths: './junit/vitest-junit.xml'`                                             |
+
+**JUnit reporter:** Use Vitest's built-in `reporters: ['junit']` with `outputFile: './junit/vitest-junit.xml'`. No additional package needed.
+
+**Coverage:** Replace `jest --coverage` (which uses Istanbul) with `vitest run --coverage` (which uses `@vitest/coverage-v8`). The coverage output format may differ; verify that SonarQube and CI coverage uploads still work.
+
+### 9. Dockerfile
+
+**No changes required.** The production Dockerfile runs `node dist/src/main.js`. With `"type": "module"` in `package.json` and ESM output from `tsc`, Node.js will load the file as ESM automatically. The `health-check.js` script will also be ESM.
+
+### 10. `getCurrentDirname()` Utility
+
+**No changes required.** The utility already returns `process.cwd()` and does not use `__dirname` or `import.meta.url`. It works identically in ESM.
+
+### 11. Scripts (`verify:assessor`, `dev:delegate`)
+
+**`verify:assessor` script:** Currently `ts-node scripts/verify-assessor.ts`. Under `"type": "module"`, `ts-node` without `--esm` will fail. Migrate to `tsx scripts/verify-assessor.ts` for better ESM support and simpler configuration.
+
+**`dev:delegate` script:** Already uses `ts-node --esm`. No change needed, but verify it works after `tsconfig.json` changes.
+
+### 12. Documentation Updates
+
+The following files contain Jest references that must be updated:
+
+| File                                          | Nature of References                                         |
+| --------------------------------------------- | ------------------------------------------------------------ |
+| `AGENTS.md`                                   | Tech stack lists Jest; file-utilities guidance mentions Jest |
+| `README.md`                                   | Tech stack lists Jest                                        |
+| `LINT_CLEANUP_PLAN.md`                        | References `jest.fn()`, `jest.Mock` patterns                 |
+| `docs/architecture/overview.md`               | Lists Jest as testing framework                              |
+| `docs/copilot-environment.md`                 | Mentions Jest for test env setup                             |
+| `docs/modules/utilities.md`                   | Documents `getCurrentDirname()` Jest compatibility           |
+| `docs/deployment/cicd.md`                     | References Jest/Istanbul for coverage, JUnit paths           |
+| `docs/development/debugging.md`               | VS Code debug config for Jest, CLI examples                  |
+| `docs/development/git-workflow.md`            | Example commit message referencing Jest                      |
+| `docs/development/workflow.md`                | Testing pyramid describes Jest; coverage enforcement         |
+| `docs/development/code-style.md`              | Code examples use `jest.fn()`, `jest.Mocked<>`               |
+| `docs/testing/README.md`                      | Framework lists, config file names, mocking guidance         |
+| `docs/testing/E2E_GUIDE.md`                   | Mocked/live config file names, shim documentation            |
+| `docs/testing/PRACTICAL_GUIDE.md`             | Code examples use `jest.fn()`                                |
+| `docs/testing/PROD_TESTS_GUIDE.md`            | References `jest-prod.config.cjs`                            |
+| `.opencode/agents/code-reviewer.md`           | Testing checklist references Jest                            |
+| `.opencode/agents/agent-orchestrator.md`      | Routing rules reference Jest                                 |
+| `.opencode/agents/testing-specialist.md`      | Entire file describes Jest patterns                          |
+| `.opencode/agents/action-plan-implementer.md` | E2E routing rule references Jest                             |
+| `.opencode/agents/docs.md`                    | Agent description references Jest                            |
+| `.github/agents/reviewer.agent.md`            | Coverage guidance references Jest                            |
+| `.github/agents/testing.agent.md`             | Coverage expectations reference Jest                         |
+
+## State Rules
+
+| #   | Rule                                           | Detail                                                           |
+| --- | ---------------------------------------------- | ---------------------------------------------------------------- |
+| S1  | No `require()` in any source or test file      | Enforced by `import-x/no-commonjs` ESLint rule (already active). |
+| S2  | No `module.exports` in any source or test file | Enforced by `import-x/no-commonjs` ESLint rule.                  |
+| S3  | No `.cjs` files in the repository              | After migration, all config files use `.ts` or `.js` (ESM).      |
+| S4  | No Jest dependencies in `package.json`         | All Jest packages removed.                                       |
+| S5  | All test files use Vitest API                  | No `jest.*` calls remain.                                        |
+| S6  | `tsconfig.json` emits ESM                      | `"module": "NodeNext"` or equivalent.                            |
+| S7  | `package.json` has `"type": "module"`          | All `.js` files treated as ESM by default.                       |
+
+## Non-Goals
+
+- Migrating from `ts-node` to `tsx` (out of scope; `ts-node` ESM hooks are sufficient).
+- Changing the NestJS version or framework.
+- Adding new business logic or features.
+- Restructuring the module system beyond what is required for ESM.
+- Changing the Docker build pipeline or base image.
+
+## Open Questions
+
+| #   | Question                                                                                                           | Resolution                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Q1  | Does `@nestjs/testing`'s `TestingModule` work correctly under Vitest with ESM output?                              | **Research completed — conditional yes.** GitHub issue #17047 (May 2026) confirms that `TestingModule` DI fails when Vitest uses SWC/esbuild because they don't emit decorator metadata. However, our project uses `tsc` for compilation, which correctly emits metadata with `emitDecoratorMetadata: true`. The risk is that Vitest's default transformer may override `tsc` output. **Mitigation:** Configure Vitest to use `tsc` as the transformer (via `@analogjs/vite-plugin-angular` or similar), or validate in Phase 0 that the default Vitest transformer preserves metadata. If it doesn't, the fallback is to add explicit `@Inject()` decorators to all constructor parameters (significant code change). |
+| Q2  | Does `nest build` (NestJS CLI) correctly produce ESM output when `tsconfig.json` is set to `"module": "NodeNext"`? | **Validation required.** The CLI uses `tsc` under the hood. Asset copying and watch mode need verification.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| Q3  | Should Vitest workspace mode be used instead of multiple config files?                                             | **Resolved: Yes, use workspace mode (decision D7).** A single `vitest.workspace.ts` is cleaner. Fall back to separate configs only if workspace mode proves problematic.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| Q4  | How should the `llm-http-shim.cjs` mocking pattern be replaced?                                                    | **Resolved: Use `vi.mock()` in E2E setup (decision D8).** The shim file and `--require` approach are deleted. `vi.mock('@google/generative-ai')` in `vitest.e2e.setup.ts` replaces the prototype monkey-patch.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Q5  | Does `reflect-metadata` work correctly under ESM?                                                                  | **Research completed — yes.** The `reflect-metadata` package is ESM-compatible. The key requirement is that it must be imported BEFORE any decorated classes are loaded. In ESM, import order is deterministic (static analysis), so importing it in the setup file or in `main.ts` before other imports will work correctly. No ESM-specific issues found in the `microsoft/reflect-metadata` repository.                                                                                                                                                                                                                                                                                                             |
+
+## Risks
+
+| #   | Risk                                                               | Likelihood | Impact | Mitigation                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --- | ------------------------------------------------------------------ | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | NestJS decorator metadata fails under ESM output                   | Low        | High   | Validate with a minimal NestJS app early (Phase 0). `emitDecoratorMetadata` is supported by `tsc` in ESM mode.                                                                                                                                                                                                                                                                                                                                                                                                  |
+| R2  | `vi.mock()` hoisting behaves differently from `jest.mock()` in ESM | Medium     | Medium | Vitest explicitly supports ESM mock hoisting. Test with the most complex mock patterns first (`gemini.service.spec.ts`, `bootstrap.spec.ts`).                                                                                                                                                                                                                                                                                                                                                                   |
+| R3  | `tsconfig-paths` does not resolve path aliases under Vitest ESM    | Low        | Medium | Vitest has built-in path alias support via `resolve.alias` in config. Configure explicitly.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| R4  | E2E child process spawning fails with ESM entry point              | Low        | High   | The child process runs the built `dist/` output. Validate that `node dist/src/testing-main.js` starts correctly with `"type": "module"`.                                                                                                                                                                                                                                                                                                                                                                        |
+| R5  | Some npm scripts or CI steps reference Jest directly               | Medium     | Low    | Grep for all `jest` references in scripts, CI configs, and documentation. Section 12 enumerates all documentation files.                                                                                                                                                                                                                                                                                                                                                                                        |
+| R6  | `reflect-metadata` import ordering breaks under ESM                | Low        | High   | Research confirms `reflect-metadata` is ESM-compatible. Ensure `import 'reflect-metadata'` is the FIRST import in `main.ts` and `vitest.setup.ts` before any NestJS imports. Validate in Phase 0.                                                                                                                                                                                                                                                                                                               |
+| R7  | `verify:assessor` script breaks under `"type": "module"`           | Medium     | Low    | The script uses `ts-node` without `--esm`. Update the npm script to include `--esm` flag or migrate to `tsx`.                                                                                                                                                                                                                                                                                                                                                                                                   |
+| R8  | Vitest's default transformer doesn't preserve decorator metadata   | Medium     | High   | **Research finding:** GitHub issue #17047 confirms that Vitest with SWC/esbuild fails to emit decorator metadata, breaking NestJS DI. Our project uses `tsc` which emits metadata correctly, but Vitest's default transformer may override this. **Mitigation:** In Phase 0, validate that Vitest's default transformer preserves metadata. If not, configure Vitest to use `tsc` as the transformer, or add explicit `@Inject()` decorators to all constructor parameters (fallback, significant code change). |
+
+## Success Criteria
+
+1. `npm run build` produces ESM output in `dist/`.
+2. `node dist/src/main.js` starts the application successfully.
+3. `npm run test` runs all unit/integration tests via Vitest and all pass.
+4. `npm run test:e2e:mocked` runs E2E tests via Vitest and all pass.
+5. `npm run test:e2e:live` runs live E2E tests via Vitest and all pass.
+6. `npm run test:prod` runs production tests via Vitest and all pass.
+7. `npm run lint` passes with no Jest-specific overrides or `.cjs` exceptions.
+8. Zero `.cjs` files remain in the repository (excluding `node_modules`).
+9. Zero `require()` or `module.exports` in any source, test, or config file.
+10. `package.json` has `"type": "module"` and no Jest dependencies.

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,7 +8,7 @@ Remove the requirement for CommonJS module output from the codebase. The codebas
 
 The ESLint configuration already documents this intent (`eslint.config.js`, lines 237–248):
 
-> _"Jest runs inside a CommonJS environment (tsconfig.module = CommonJS) that lacks both top-level await support and the Uint8Array.fromBase64() method... These overrides will be removed when the project migrates from Jest to ViTest (which supports ESM natively), eliminating both constraints in a single change."_
+> _"Jest runs inside a CommonJS environment (tsconfig.module = CommonJS) that lacks both top-level await support and the Uint8Array.fromBase64() method... These overrides will be removed when the project migrates from Jest to Vitest (which supports ESM natively), eliminating both constraints in a single change."_
 
 The source code is already pure ESM syntax. Zero `require()`, `module.exports`, `__dirname`, or `__filename` calls exist in any `.ts` source file. The CommonJS requirement is entirely in configuration and test infrastructure.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# AssessmentBot-Backend Documentation
+# Assessment Bot LLM Service Documentation
 
-Welcome to the comprehensive documentation for the AssessmentBot-Backend project. This documentation provides detailed information about the architecture, development, deployment, and usage of the assessment system.
+Welcome to the comprehensive documentation for the Assessment Bot LLM Service project. This documentation provides detailed information about the architecture, development, deployment, and usage of the assessment system.
 
 ## Table of Contents
 

--- a/docs/api/API_Documentation.md
+++ b/docs/api/API_Documentation.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document provides an overview of the Assessment Bot Backend API, detailing available endpoints, authentication methods, and data structures.
+This document provides an overview of the Assessment Bot LLM Service API, detailing available endpoints, authentication methods, and data structures.
 
 ## Base URL
 

--- a/docs/api/error-codes.md
+++ b/docs/api/error-codes.md
@@ -1,6 +1,6 @@
 # Error Codes
 
-This document details the error handling mechanisms and HTTP status codes returned by the Assessment Bot Backend API, including error formats, common scenarios, and troubleshooting guidance.
+This document details the error handling mechanisms and HTTP status codes returned by the Assessment Bot LLM Service API, including error formats, common scenarios, and troubleshooting guidance.
 
 ## Overview
 

--- a/docs/api/rate-limiting.md
+++ b/docs/api/rate-limiting.md
@@ -1,6 +1,6 @@
 # Rate Limiting
 
-This document details the rate limiting (throttling) implementation in the Assessment Bot Backend API.
+This document details the rate limiting (throttling) implementation in the Assessment Bot LLM Service API.
 
 ## Overview
 

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1,6 +1,6 @@
 # Request & Response Schemas
 
-This document details the data schemas for the Assessment Bot Backend API, validated using Zod.
+This document details the data schemas for the Assessment Bot LLM Service API, validated using Zod.
 
 ## Assessment Request (`/v1/assessor`)
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -1,6 +1,6 @@
 # Data Flow
 
-This document describes the complete request/response flow through the AssessmentBot-Backend system, from initial HTTP request to final LLM response.
+This document describes the complete request/response flow through the Assessment Bot LLM Service system, from initial HTTP request to final LLM response.
 
 ## Overview
 

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -1,6 +1,6 @@
 # Module Responsibilities
 
-This document provides a detailed breakdown of each module in the AssessmentBot-Backend system, including their responsibilities, dependencies, and key components.
+This document provides a detailed breakdown of each module in the Assessment Bot LLM Service system, including their responsibilities, dependencies, and key components.
 
 ## Core Modules
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-This document provides a comprehensive overview of the AssessmentBot-Backend architecture, a NestJS-based API service that leverages Large Language Models (LLMs) to provide automated assessment services for educational content.
+This document provides a comprehensive overview of the Assessment Bot LLM Service architecture, a NestJS-based API service that leverages Large Language Models (LLMs) to provide automated assessment services for educational content.
 
 ## High-Level Architecture
 
@@ -172,7 +172,7 @@ The system uses NestJS's built-in dependency injection container with the follow
 
 #### Environment Differences: Production vs. Development
 
-The AssessmentBot-Backend project uses two different Node.js environments to optimize for both production reliability and development convenience:
+The Assessment Bot LLM Service project uses two different Node.js environments to optimize for both production reliability and development convenience:
 
 - **Production (`node:22-alpine`)**: The production Docker image is based on the official `node:22-alpine` image. Alpine Linux is chosen for its minimal footprint, resulting in smaller, faster, and more secure containers. This environment is highly optimized for deployment and does not include extra development tools or utilities.
 

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -1,6 +1,6 @@
 # Design Patterns
 
-This document catalogues the design patterns used throughout the AssessmentBot-Backend codebase, explaining their implementation, benefits, and specific use cases within the system.
+This document catalogues the design patterns used throughout the Assessment Bot LLM Service codebase, explaining their implementation, benefits, and specific use cases within the system.
 
 ## Creational Patterns
 

--- a/docs/auth/API_Key_Management.md
+++ b/docs/auth/API_Key_Management.md
@@ -1,6 +1,6 @@
 # API Key Management
 
-This document outlines best practices for managing API keys within the Assessment Bot Backend, covering generation, rotation, usage, and security considerations.
+This document outlines best practices for managing API keys within the Assessment Bot LLM Service, covering generation, rotation, usage, and security considerations.
 
 ## 1. API Key Generation Best Practices
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -19,7 +19,7 @@ These variables have default values but can be customised to change application 
 
 - `NODE_ENV`: Application environment (`development`, `production`, `test`). Default is `production`.
 - `PORT`: Port on which the server runs. Default is `3000`.
-- `APP_NAME`: Application name. Default is `AssessmentBot-Backend`.
+- `APP_NAME`: Application name. Default is `Assessment Bot LLM Service`.
 - `APP_VERSION`: Application version. Optional, defaults to the version in `package.json`.
 - `LOG_LEVEL`: Logging verbosity level (`fatal`, `error`, `warn`, `info`, `debug`, `verbose`). Default is `info`.
 

--- a/docs/copilot-environment.md
+++ b/docs/copilot-environment.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Coding Agent Environment Setup
 
-This document outlines the GitHub Copilot Coding Agent environment configuration for the AssessmentBot-Backend repository.
+This document outlines the GitHub Copilot Coding Agent environment configuration for the Assessment Bot LLM Service repository.
 
 ## Overview
 

--- a/docs/deployment/cicd.md
+++ b/docs/deployment/cicd.md
@@ -1,6 +1,6 @@
 # CI/CD Pipeline
 
-This guide covers the continuous integration and deployment pipeline for the AssessmentBot-Backend project using GitHub Actions.
+This guide covers the continuous integration and deployment pipeline for the Assessment Bot LLM Service project using GitHub Actions.
 
 ## Overview
 
@@ -36,7 +36,7 @@ The CI pipeline (`/.github/workflows/ci.yml`) runs on every pull request and inc
 
 # CI/CD Pipeline
 
-This guide covers the continuous integration and deployment pipeline for the AssessmentBot-Backend project using GitHub Actions.
+This guide covers the continuous integration and deployment pipeline for the Assessment Bot LLM Service project using GitHub Actions.
 
 ## Overview
 
@@ -64,7 +64,7 @@ The CI pipeline (`/.github/workflows/ci.yml`) runs on every pull request and inc
 
 # CI/CD Pipeline
 
-This guide covers the continuous integration and deployment pipeline for the AssessmentBot-Backend project using GitHub Actions.
+This guide covers the continuous integration and deployment pipeline for the Assessment Bot LLM Service project using GitHub Actions.
 
 ## Overview
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,10 +1,10 @@
 # Docker Deployment
 
-This guide covers the containerised deployment of the AssessmentBot-Backend using Docker and Docker Compose.
+This guide covers the containerised deployment of the Assessment Bot LLM Service using Docker and Docker Compose.
 
 ## Overview
 
-The AssessmentBot-Backend supports two Docker deployment scenarios:
+The Assessment Bot LLM Service supports two Docker deployment scenarios:
 
 - **Development**: Local development with hot-reloading and debugging capabilities, using `Docker/Dockerfile`.
 - **Production**: Optimised, secure containers for production environments, using `Docker/Dockerfile.prod`.
@@ -16,8 +16,8 @@ The production image uses a multi-stage build to create a minimal, secure runtim
 1.  **Clone the repository**:
 
     ```bash
-    git clone https://github.com/h-arnold/AssessmentBot-Backend.git
-    cd AssessmentBot-Backend
+    git clone https://github.com/h-arnold/Assessment Bot LLM Service.git
+    cd Assessment Bot LLM Service
     ```
 
 2.  **Set up environment variables**:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -16,8 +16,8 @@ The production image uses a multi-stage build to create a minimal, secure runtim
 1.  **Clone the repository**:
 
     ```bash
-    git clone https://github.com/h-arnold/Assessment Bot LLM Service.git
-    cd Assessment Bot LLM Service
+    git clone https://github.com/h-arnold/AssessmentBot-LLM-Service.git
+    cd AssessmentBot-LLM-Service
     ```
 
 2.  **Set up environment variables**:

--- a/docs/deployment/monitoring.md
+++ b/docs/deployment/monitoring.md
@@ -1,6 +1,6 @@
 # Monitoring & Observability
 
-This guide covers the built-in monitoring, logging, and observability features of the AssessmentBot-Backend application.
+This guide covers the built-in monitoring, logging, and observability features of the Assessment Bot LLM Service application.
 
 ## Overview
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -1,6 +1,6 @@
 # Production Setup
 
-This guide covers a typical production environment configuration for the AssessmentBot-Backend application.
+This guide covers a typical production environment configuration for the Assessment Bot LLM Service application.
 
 ## Server Requirements
 
@@ -45,7 +45,7 @@ sudo ufw allow 443   # HTTPS
 1.  **Clone the repository:**
 
     ```bash
-    git clone https://github.com/h-arnold/AssessmentBot-Backend.git /opt/assessmentbot
+    git clone https://github.com/h-arnold/Assessment Bot LLM Service.git /opt/assessmentbot
     cd /opt/assessmentbot
     ```
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -45,7 +45,7 @@ sudo ufw allow 443   # HTTPS
 1.  **Clone the repository:**
 
     ```bash
-    git clone https://github.com/h-arnold/Assessment Bot LLM Service.git /opt/assessmentbot
+    git clone https://github.com/h-arnold/AssessmentBot-LLM-Service.git /opt/assessmentbot
     cd /opt/assessmentbot
     ```
 

--- a/docs/development/code-style.md
+++ b/docs/development/code-style.md
@@ -1,6 +1,6 @@
 # Code Style Guide
 
-This document outlines the coding standards and conventions for the AssessmentBot-Backend project.
+This document outlines the coding standards and conventions for the Assessment Bot LLM Service project.
 
 ## Language and Spelling Standards
 

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -1,6 +1,6 @@
 # Debugging Guide
 
-This document provides comprehensive guidance on debugging techniques and tools available for the AssessmentBot-Backend project.
+This document provides comprehensive guidance on debugging techniques and tools available for the Assessment Bot LLM Service project.
 
 ## Debugging Setup
 

--- a/docs/development/git-workflow.md
+++ b/docs/development/git-workflow.md
@@ -1,6 +1,6 @@
 # Git Workflow
 
-This document outlines the branching strategy and commit conventions for the AssessmentBot-Backend project.
+This document outlines the branching strategy and commit conventions for the Assessment Bot LLM Service project.
 
 ## Branching Strategy
 

--- a/docs/development/workflow.md
+++ b/docs/development/workflow.md
@@ -17,8 +17,8 @@ Before starting development, ensure you have the following installed:
 ### 1. Clone and Install Dependencies
 
 ```bash
-git clone https://github.com/h-arnold/Assessment Bot LLM Service.git
-cd Assessment Bot LLM Service
+git clone https://github.com/h-arnold/AssessmentBot-LLM-Service.git
+cd AssessmentBot-LLM-Service
 npm install
 ```
 

--- a/docs/development/workflow.md
+++ b/docs/development/workflow.md
@@ -1,6 +1,6 @@
 # Development Workflow
 
-This document outlines the local development practices and procedures for the AssessmentBot-Backend project.
+This document outlines the local development practices and procedures for the Assessment Bot LLM Service project.
 
 ## Prerequisites
 
@@ -17,8 +17,8 @@ Before starting development, ensure you have the following installed:
 ### 1. Clone and Install Dependencies
 
 ```bash
-git clone https://github.com/h-arnold/AssessmentBot-Backend.git
-cd AssessmentBot-Backend
+git clone https://github.com/h-arnold/Assessment Bot LLM Service.git
+cd Assessment Bot LLM Service
 npm install
 ```
 

--- a/docs/modules/app.md
+++ b/docs/modules/app.md
@@ -1,6 +1,6 @@
 # App Module
 
-The App Module (`src/app.module.ts`) is the root module of the AssessmentBot-Backend application, responsible for orchestrating and wiring together all other modules in the system.
+The App Module (`src/app.module.ts`) is the root module of the Assessment Bot LLM Service application, responsible for orchestrating and wiring together all other modules in the system.
 
 ## Overview
 

--- a/docs/modules/assessor.md
+++ b/docs/modules/assessor.md
@@ -1,6 +1,6 @@
 # Assessor Module (v1)
 
-The Assessor Module (`src/v1/assessor/`) is the core assessment functionality of the AssessmentBot-Backend application, responsible for processing assessment requests and generating comprehensive evaluations using Large Language Models.
+The Assessor Module (`src/v1/assessor/`) is the core assessment functionality of the Assessment Bot LLM Service application, responsible for processing assessment requests and generating comprehensive evaluations using Large Language Models.
 
 ## Overview
 

--- a/docs/modules/auth.md
+++ b/docs/modules/auth.md
@@ -1,6 +1,6 @@
 # Authentication Module (`AuthModule`)
 
-This document provides an overview of the `AuthModule`, which is responsible for handling all authentication and authorisation concerns within the AssessmentBot-Backend.
+This document provides an overview of the `AuthModule`, which is responsible for handling all authentication and authorisation concerns within the Assessment Bot LLM Service.
 
 ## Primary Responsibility
 

--- a/docs/modules/common.md
+++ b/docs/modules/common.md
@@ -1,6 +1,6 @@
 # Common Module
 
-The Common Module (`src/common/common.module.ts`) provides a set of shared, injectable services and globally applied filters used across the AssessmentBot-Backend application.
+The Common Module (`src/common/common.module.ts`) provides a set of shared, injectable services and globally applied filters used across the Assessment Bot LLM Service application.
 
 ## Overview
 

--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -1,6 +1,6 @@
 # Config Module
 
-The Config Module (`src/config/config.module.ts`) provides validation-aware configuration management for the AssessmentBot-Backend application. It acts as an architectural boundary that ensures all configuration access is validated and type-safe.
+The Config Module (`src/config/config.module.ts`) provides validation-aware configuration management for the Assessment Bot LLM Service application. It acts as an architectural boundary that ensures all configuration access is validated and type-safe.
 
 ## Overview
 
@@ -98,7 +98,7 @@ Configuration is validated against the `configSchema` defined in `src/config/env
 export const configSchema = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']),
   PORT: z.coerce.number().int().min(1).max(65535).default(3000),
-  APP_NAME: z.string().default('AssessmentBot-Backend'),
+  APP_NAME: z.string().default('Assessment Bot LLM Service'),
   APP_VERSION: z.string().optional(),
   API_KEYS: z.string().optional().transform(/* comma-separated to array */),
   MAX_IMAGE_UPLOAD_SIZE_MB: z.coerce.number().int().min(0).default(1),
@@ -124,7 +124,7 @@ export const configSchema = z.object({
 
 - `NODE_ENV`: Environment mode (development/production/test)
 - `PORT`: Server port (default: 3000)
-- `APP_NAME`: Application identifier (default: 'AssessmentBot-Backend')
+- `APP_NAME`: Application identifier (default: 'Assessment Bot LLM Service')
 - `APP_VERSION`: Optional version string
 
 #### Authentication & Security

--- a/docs/modules/llm.md
+++ b/docs/modules/llm.md
@@ -1,6 +1,6 @@
 # LLM Module
 
-The LLM Module (`src/llm/`) provides Large Language Model integration services for the AssessmentBot-Backend application, implementing an abstract service layer with Google Gemini as the concrete implementation.
+The LLM Module (`src/llm/`) provides Large Language Model integration services for the Assessment Bot LLM Service application, implementing an abstract service layer with Google Gemini as the concrete implementation.
 
 ## Overview
 

--- a/docs/modules/prompt.md
+++ b/docs/modules/prompt.md
@@ -1,6 +1,6 @@
 # Prompt Module
 
-The Prompt Module (`src/prompt/`) provides prompt generation and management services for the AssessmentBot-Backend application, implementing a factory pattern to create task-specific prompts for LLM assessment requests.
+The Prompt Module (`src/prompt/`) provides prompt generation and management services for the Assessment Bot LLM Service application, implementing a factory pattern to create task-specific prompts for LLM assessment requests.
 
 ## Overview
 

--- a/docs/modules/status.md
+++ b/docs/modules/status.md
@@ -1,6 +1,6 @@
 # Status Module
 
-The Status Module (`src/status/`) provides health checks and system status functionality for the AssessmentBot-Backend application, offering essential monitoring and diagnostic capabilities for operational oversight.
+The Status Module (`src/status/`) provides health checks and system status functionality for the Assessment Bot LLM Service application, offering essential monitoring and diagnostic capabilities for operational oversight.
 
 ## Overview
 

--- a/docs/prompts/README.md
+++ b/docs/prompts/README.md
@@ -1,6 +1,6 @@
 # Prompt System
 
-This document outlines the architecture and development process for the prompt generation system used in the AssessmentBot-Backend.
+This document outlines the architecture and development process for the prompt generation system used in the Assessment Bot LLM Service.
 
 ## Architecture
 

--- a/docs/prompts/templates.md
+++ b/docs/prompts/templates.md
@@ -1,6 +1,6 @@
 # Template Management
 
-This guide covers the management of prompt templates in the AssessmentBot-Backend system. Templates are crucial for maintaining consistent and effective LLM interactions whilst allowing for customisation across different task types.
+This guide covers the management of prompt templates in the Assessment Bot LLM Service system. Templates are crucial for maintaining consistent and effective LLM interactions whilst allowing for customisation across different task types.
 
 ## Template Overview
 

--- a/docs/security/auth.md
+++ b/docs/security/auth.md
@@ -1,6 +1,6 @@
 # Authentication & Authorisation
 
-This document provides a detailed technical breakdown of the authentication and authorisation mechanism implemented in the AssessmentBot-Backend.
+This document provides a detailed technical breakdown of the authentication and authorisation mechanism implemented in the Assessment Bot LLM Service.
 
 ## Overview
 

--- a/docs/testing/E2E_GUIDE.md
+++ b/docs/testing/E2E_GUIDE.md
@@ -1,6 +1,6 @@
 # E2E Testing Guide
 
-This document provides instructions for setting up and running the End-to-End (E2E) tests for the AssessmentBot-Backend.
+This document provides instructions for setting up and running the End-to-End (E2E) tests for the Assessment Bot LLM Service.
 
 ## Running E2E Tests
 

--- a/docs/testing/PRACTICAL_GUIDE.md
+++ b/docs/testing/PRACTICAL_GUIDE.md
@@ -1,6 +1,6 @@
 # Practical Testing Guide
 
-This document provides practical examples and patterns for writing effective unit tests and managing test data in the AssessmentBot-Backend project.
+This document provides practical examples and patterns for writing effective unit tests and managing test data in the Assessment Bot LLM Service project.
 
 ## 1. Unit & Integration Testing
 

--- a/docs/testing/PROD_TESTS_GUIDE.md
+++ b/docs/testing/PROD_TESTS_GUIDE.md
@@ -1,6 +1,6 @@
 # Production Image Testing Guide
 
-This document provides instructions for running tests against a production-like Docker image of the AssessmentBot-Backend.
+This document provides instructions for running tests against a production-like Docker image of the Assessment Bot LLM Service.
 
 ## Overview
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,6 +1,6 @@
 # Testing Guide
 
-This document provides a concise overview of the testing strategy, tools, and practices for the AssessmentBot-Backend project.
+This document provides a concise overview of the testing strategy, tools, and practices for the Assessment Bot LLM Service project.
 
 ## Guiding Principles
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import stylistic from '@stylistic/eslint-plugin';
 import prettier from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import-x';
 import jest from 'eslint-plugin-jest';
+import jsdoc from 'eslint-plugin-jsdoc';
 import n from 'eslint-plugin-n';
 import noSecrets from 'eslint-plugin-no-secrets';
 import regexp from 'eslint-plugin-regexp';
@@ -20,6 +21,7 @@ export default tseslint.config(
       '@typescript-eslint': tseslint.plugin,
       '@stylistic': stylistic,
       jest,
+      jsdoc,
       'no-secrets': noSecrets,
       n,
       regexp,
@@ -209,6 +211,20 @@ export default tseslint.config(
       'n/no-path-concat': 'error',
       '@typescript-eslint/no-var-requires': 'error',
       'import-x/no-commonjs': 'error',
+
+      // JSDoc rules to enforce documentation standards
+      ...jsdoc.configs['recommended'].rules,
+      'jsdoc/require-description-complete-sentence': [
+        'warn',
+        {
+          treatSingleLinePhrasesAsIncomplete: true,
+        },
+      ],
+      'jsdoc/require-returns': 'error',
+      'jsdoc/require-returns-description': 'error',
+      'jsdoc/require-param-description': 'error',
+      'jsdoc/require-example': 'off',
+      'jsdoc/require-description': 'error',
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -213,13 +213,22 @@ export default tseslint.config(
       'import-x/no-commonjs': 'error',
 
       // JSDoc rules to enforce documentation standards
-      ...jsdoc.configs['recommended'].rules,
-      'jsdoc/require-description-complete-sentence': 'warn',
+      // Use TypeScript-specific recommended config — it disables type
+      // annotations in JSDoc blocks (TypeScript already provides types)
+      // and enables no-types to flag redundant annotations
+      ...jsdoc.configs['flat/recommended-typescript'].rules,
+      // Override check-tag-names to avoid warnings for conventional
+      // NestJS documentation tags (@module, @class, @abstract, @property)
+      // that are redundant in TypeScript but idiomatic in this codebase
+      'jsdoc/check-tag-names': ['warn', { typed: false }],
+      'jsdoc/no-types': 'off',
+      'jsdoc/require-description-complete-sentence': 'error',
       'jsdoc/require-returns': 'error',
       'jsdoc/require-returns-description': 'error',
       'jsdoc/require-param-description': 'error',
       'jsdoc/require-example': 'off',
       'jsdoc/require-description': 'error',
+      'jsdoc/require-throws-description': 'error',
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -214,12 +214,7 @@ export default tseslint.config(
 
       // JSDoc rules to enforce documentation standards
       ...jsdoc.configs['recommended'].rules,
-      'jsdoc/require-description-complete-sentence': [
-        'warn',
-        {
-          treatSingleLinePhrasesAsIncomplete: true,
-        },
-      ],
+      'jsdoc/require-description-complete-sentence': 'warn',
       'jsdoc/require-returns': 'error',
       'jsdoc/require-returns-description': 'error',
       'jsdoc/require-param-description': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "assessmentbot-backend",
+  "name": "assessmentbot-llm-service",
   "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "assessmentbot-backend",
+      "name": "assessmentbot-llm-service",
       "version": "0.1.12",
       "license": "ISC",
       "dependencies": {
@@ -54,6 +54,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-jest": "^29.15.2",
+        "eslint-plugin-jsdoc": "^63.0.11",
         "eslint-plugin-n": "^18.2.1",
         "eslint-plugin-no-secrets": "^2.3.3",
         "eslint-plugin-prettier": "^5.5.5",
@@ -809,6 +810,33 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.88.0.tgz",
+      "integrity": "sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.59.4",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2806,6 +2834,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -4296,6 +4337,16 @@
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -5860,6 +5911,66 @@
         }
       }
     },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "63.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.11.tgz",
+      "integrity": "sha512-QhLmqREgRJSIKg0r23ckTVaNK1lmMsTmpyY5Hv7NTCHNWTFZx/8PqycWhR0p0Lk/U5aJ6H3zAKMQ0xB2NkN0sA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.88.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-plugin-n": {
       "version": "18.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.2.1.tgz",
@@ -7212,6 +7323,23 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -9446,6 +9574,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -9655,6 +9790,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -9673,6 +9818,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -10342,6 +10494,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -10838,6 +11003,31 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -11498,6 +11688,23 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-jest": "^29.15.2",
+    "eslint-plugin-jsdoc": "^63.0.11",
     "eslint-plugin-n": "^18.2.1",
     "eslint-plugin-no-secrets": "^2.3.3",
     "eslint-plugin-prettier": "^5.5.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "ISC",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "build": "nest build",
@@ -110,7 +110,7 @@
       "ajv": "8.18.0"
     }
   },
-  "homepage": "https://github.com/h-arnold/Assessment Bot LLM Service#readme",
+  "homepage": "https://github.com/h-arnold/AssessmentBot-LLM-Service#readme",
   "lint-staged": {
     "*.ts": "eslint --fix",
     "*.{js,ts,json,md}": "prettier --write",
@@ -118,9 +118,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/h-arnold/Assessment Bot LLM Service.git"
+    "url": "git+https://github.com/h-arnold/AssessmentBot-LLM-Service.git"
   },
   "bugs": {
-    "url": "https://github.com/h-arnold/Assessment Bot LLM Service/issues"
+    "url": "https://github.com/h-arnold/AssessmentBot-LLM-Service/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "assessmentbot-backend",
+  "name": "assessmentbot-llm-service",
   "version": "0.1.12",
   "description": "The backend for Assessment Bot, which provides LLM services.",
   "author": "Hamish Arnold",
@@ -109,7 +109,7 @@
       "ajv": "8.18.0"
     }
   },
-  "homepage": "https://github.com/h-arnold/AssessmentBot-Backend#readme",
+  "homepage": "https://github.com/h-arnold/Assessment Bot LLM Service#readme",
   "lint-staged": {
     "*.ts": "eslint --fix",
     "*.{js,ts,json,md}": "prettier --write",
@@ -117,9 +117,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/h-arnold/AssessmentBot-Backend.git"
+    "url": "git+https://github.com/h-arnold/Assessment Bot LLM Service.git"
   },
   "bugs": {
-    "url": "https://github.com/h-arnold/AssessmentBot-Backend/issues"
+    "url": "https://github.com/h-arnold/Assessment Bot LLM Service/issues"
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,12 @@ import { StatusModule } from './status/status.module';
 import { AssessorModule } from './v1/assessor/assessor.module';
 
 // Type guard to check if req has an id property of type string or number
+/**
+ * Type guard to check whether an incoming message has an id property.
+ * @param {IncomingMessage} request - The incoming HTTP request message.
+ * @returns {request is IncomingMessage & { id: string | number }} True if the
+ *   request has an id of type string or number.
+ */
 function hasRequestId(
   request: IncomingMessage,
 ): request is IncomingMessage & { id: string | number } {
@@ -25,11 +31,14 @@ function hasRequestId(
 }
 
 /**
+ * The root module of the application, responsible for orchestrating and wiring
+ * together all other modules.
+ * @param {IncomingMessage} request - The incoming HTTP request message.
+ * @param {ServerResponse<IncomingMessage>} _response - The outgoing server
+ *   response (unused).
+ * @returns {{ reqId: string | number | undefined }} The custom logging properties
+ *   containing the request id, if present.
  * @module AppModule
- *
- * @description
- * The root module of the application, responsible for orchestrating and wiring together all other modules.
- *
  * @remarks
  * **Module Initialization Order:**
  * The order of module imports is significant. `ConfigModule` is imported first to ensure that environment
@@ -49,7 +58,6 @@ function hasRequestId(
  *
  * This setup provides a baseline level of protection against abuse, which can then be fine-tuned for specific
  * resource-intensive or authenticated endpoints.
- *
  * @see config/throttler.config.ts - For the source of the default throttler configuration.
  * @see v1/assessor/assessor.controller.ts - For an example of how to override the global throttler settings.
  */

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -5,15 +5,15 @@ import { AuthGuard } from '@nestjs/passport';
  * A guard that extends the `AuthGuard` with the 'bearer' strategy.
  * This guard is used to authenticate requests based on API keys
  * provided in the Authorization header using the Bearer token format.
- *
  * @example
+ * ```typescript
  * // Usage in a controller
- * @UseGuards(ApiKeyGuard)
- * @Get('protected-route')
+ * \@UseGuards(ApiKeyGuard)
+ * \@Get('protected-route')
  * async getProtectedData() {
  *   return 'This route is protected by the ApiKeyGuard';
  * }
- *
+ * ```
  * @see AuthGuard
  */
 @Injectable()

--- a/src/auth/api-key.service.ts
+++ b/src/auth/api-key.service.ts
@@ -23,9 +23,10 @@ export class ApiKeyService {
 
   /**
    * Constructs the ApiKeyService and loads valid API keys from configuration.
-   *
-   * @param configService - Service providing access to application configuration
-   * @param logger - Optional logger instance for recording authentication events
+   * @param {ConfigService} configService - Service providing access to
+   *   application configuration.
+   * @param {Logger} logger - Optional logger instance for recording
+   *   authentication events.
    */
   constructor(
     private readonly configService: ConfigService,
@@ -48,11 +49,11 @@ export class ApiKeyService {
    *
    * This method performs comprehensive validation including:
    * - Format validation (minimum length, character set)
-   * - Authorisation check against configured valid keys
-   *
-   * @param apiKey - The API key to validate (can be of any type initially)
-   * @returns A User object if the key is valid
-   * @throws {UnauthorizedException} If the API key is invalid or malformed
+   * - Authorisation check against configured valid keys.
+   * @param {unknown} apiKey - The API key to validate (can be of any type
+   *   initially).
+   * @returns {User | null} A User object if the key is valid.
+   * @throws {UnauthorizedException} If the API key is invalid or malformed.
    */
   validate(apiKey: unknown): User | null {
     this.logger.debug(`Attempting to validate an API key.`);

--- a/src/auth/api-key.strategy.ts
+++ b/src/auth/api-key.strategy.ts
@@ -8,7 +8,6 @@ import { User } from './user.interface';
 
 /**
  * Implements the passport-http-bearer strategy for API key authentication.
- *
  * @remarks
  * This strategy validates API keys sent in the `Authorization` header using the Bearer scheme.
  * It ensures that the scheme is correctly formatted (i.e., `Bearer <token>`) and that the
@@ -18,7 +17,6 @@ import { User } from './user.interface';
  * such as using a lowercase `bearer` or omitting the space after the scheme.
  * When a malformed scheme is detected, it logs a warning for administrative review
  * while returning a generic `401 Unauthorized` response to the client.
- *
  * @see {@link https://www.passportjs.org/packages/passport-http-bearer/}
  */
 @Injectable()
@@ -27,8 +25,8 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'bearer') {
 
   /**
    * Constructs the ApiKeyStrategy.
-   *
-   * @param apiKeyService - The service responsible for validating API keys.
+   * @param {ApiKeyService} apiKeyService - The service responsible for
+   *   validating API keys.
    */
   constructor(private readonly apiKeyService: ApiKeyService) {
     super({ passReqToCallback: true });
@@ -36,12 +34,13 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'bearer') {
 
   /**
    * Validates the API key from the request.
-   *
-   * @param request - The incoming Express request object.
-   * @param apiKey - The API key extracted from the `Authorization` header.
-   *
-   * @returns The user object associated with the validated API key.
-   * @throws {UnauthorizedException} If the Bearer scheme is malformed, the API key is invalid, or no user is found.
+   * @param {Request} request - The incoming Express request object.
+   * @param {string} apiKey - The API key extracted from the `Authorization`
+   *   header.
+   * @returns {Promise<User>} The user object associated with the validated API
+   *   key.
+   * @throws {UnauthorizedException} If the Bearer scheme is malformed, the API
+   *   key is invalid, or no user is found.
    */
   async validate(request: Request, apiKey: string): Promise<User> {
     const authHeader = request.headers.authorization;

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,20 +10,19 @@ import { ConfigModule } from '../config/config.module';
  * The `AuthModule` is responsible for managing authentication-related functionality
  * within the application. It integrates various services, strategies, and guards
  * to handle API key-based authentication.
- *
  * @module AuthModule
  *
- * @imports
+ * **imports:**
  * - `PassportModule`: Provides authentication middleware and strategies.
  * - `ConfigModule`: Handles application configuration and environment variables.
  *
- * @providers
+ * **providers:**
  * - `ApiKeyStrategy`: Defines the strategy for API key authentication.
  * - `ApiKeyGuard`: Protects routes by enforcing API key authentication.
  * - `ApiKeyService`: Provides services related to API key management.
  * - `Logger`: Logs authentication-related activities.
  *
- * @exports
+ * **exports:**
  * - `ApiKeyStrategy`: Makes the API key strategy available for use in other modules.
  * - `ApiKeyGuard`: Allows other modules to enforce API key authentication.
  * - `ApiKeyService`: Enables other modules to utilise API key management services.

--- a/src/auth/user.interface.ts
+++ b/src/auth/user.interface.ts
@@ -6,6 +6,6 @@
  * API key that was used for authentication.
  */
 export interface User {
-  /** The validated API key that was used to authenticate the user */
+  /** The validated API key that was used to authenticate the user. */
   apiKey: string;
 }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -12,6 +12,11 @@ export interface BootstrapOptions {
 
 type ExpressAppWithSet = Pick<Express, 'set'>;
 
+/**
+ * Bootstrap the NestJS application with the provided options.
+ * @param {BootstrapOptions} options - Configuration options for bootstrapping
+ *   the application.
+ */
 export async function bootstrap(options: BootstrapOptions = {}): Promise<void> {
   const { bufferLogs = true, host = '0.0.0.0' } = options;
   const app = await NestFactory.create(AppModule, {
@@ -21,9 +26,7 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<void> {
   app.useGlobalInterceptors(new LoggerErrorInterceptor());
 
   // Set Express query parser to 'extended' for compatibility with qs-style query strings
-  const expressApp = app
-    .getHttpAdapter()
-    .getInstance() as ExpressAppWithSet;
+  const expressApp = app.getHttpAdapter().getInstance() as ExpressAppWithSet;
   expressApp.set('query parser', 'extended');
 
   const configService = app.get(ConfigService);

--- a/src/common/file-utilities.ts
+++ b/src/common/file-utilities.ts
@@ -6,8 +6,9 @@ import path from 'node:path';
  *
  * Returns `process.cwd()` which is the standard way to resolve paths relative
  * to the project root in both Jest and production environments.
- *
- * @param fallbackDirectory - Fallback directory, defaults to process.cwd()
+ * @param {string} [fallbackDirectory] - Fallback directory, defaults to
+ *   process.cwd().
+ * @returns {string} The resolved directory path.
  */
 export function getCurrentDirname(fallbackDirectory?: string): string {
   return fallbackDirectory ?? process.cwd();
@@ -18,12 +19,14 @@ export function getCurrentDirname(fallbackDirectory?: string): string {
  *
  * This method ensures security by validating the filename and path to prevent
  * path traversal attacks and unauthorized file access.
- *
- * @param name - The name of the markdown file to read. Must end with `.md` and
- *               must not contain path traversal sequences (`..`).
- * @param basePath - The base directory to read from. Defaults to 'src/prompt/templates'.
- * @returns A promise that resolves to the content of the markdown file as a string.
- * @throws {Error} If the filename is invalid or the resolved path is unauthorized.
+ * @param {string} name - The name of the markdown file to read. Must end with
+ *   `.md` and must not contain path traversal sequences (`..`).
+ * @param {string} [basePath] - The base directory to read from. Defaults to
+ *   'src/prompt/templates'.
+ * @returns {Promise<string>} A promise that resolves to the content of the
+ *   markdown file as a string.
+ * @throws {Error} If the filename is invalid or the resolved path is
+ *   unauthorized.
  */
 export async function readMarkdown(
   name: string,

--- a/src/common/http-exception.filter.spec.ts
+++ b/src/common/http-exception.filter.spec.ts
@@ -15,24 +15,35 @@ interface JsonErrorResponseBody {
   path: string;
 }
 
+/**
+ * Create a mock response object that only has a json method.
+ * @returns {{ json: () => void }} A mock response object.
+ */
 function createStatusOnlyResponse(): { json: () => void } {
   return { json: (): void => {} };
 }
 
+/**
+ * Assert that the mock JSON response matches the expected error body.
+ * @param {jest.Mock} mockJson - The mock JSON function.
+ * @param {Omit<JsonErrorResponseBody, 'timestamp'>} expectedBody - The expected
+ *   error response body (without timestamp).
+ */
 function expectJsonErrorResponse(
   mockJson: jest.Mock,
   expectedBody: Omit<JsonErrorResponseBody, 'timestamp'>,
 ): void {
   const firstCall = mockJson.mock.calls[0] as
-    | [JsonErrorResponseBody]
-    | undefined;
+    [JsonErrorResponseBody] | undefined;
 
   expect(firstCall).toBeDefined();
 
   const [responseBody] = firstCall as [JsonErrorResponseBody];
 
   expect(
-    Object.keys(responseBody).toSorted((left, right) => left.localeCompare(right)),
+    Object.keys(responseBody).toSorted((left, right) =>
+      left.localeCompare(right),
+    ),
   ).toEqual(['message', 'path', 'statusCode', 'timestamp']);
 
   expect(responseBody.statusCode).toBe(expectedBody.statusCode);
@@ -196,14 +207,15 @@ describe('HttpExceptionFilter', () => {
      *
      * This mock provides implementations for `getResponse`, `getRequest`, and `getNext` methods,
      * allowing tests to simulate the behavior of the HTTP context within exception filters or interceptors.
-     *
      * @returns An object with mocked `getResponse`, `getRequest`, and `getNext` methods.
      */
-    const mockHttpArgumentsHost: jest.Mock = jest.fn().mockImplementation(() => ({
-      getResponse: mockGetResponse,
-      getRequest: mockGetRequest,
-      getNext: jest.fn(() => {}),
-    }));
+    const mockHttpArgumentsHost: jest.Mock = jest
+      .fn()
+      .mockImplementation(() => ({
+        getResponse: mockGetResponse,
+        getRequest: mockGetRequest,
+        getNext: jest.fn(() => {}),
+      }));
     /**
      * A mock implementation of the NestJS `ArgumentsHost` interface for use in unit tests.
      *
@@ -274,7 +286,6 @@ describe('HttpExceptionFilter', () => {
      * - `method`: The HTTP method used (`POST`).
      * - `ip`: The IP address of the requester (`127.0.0.1`).
      * - `headers`: An object containing request headers (with `'user-agent': 'jest'`).
-     *
      * @returns An object representing a mock HTTP request.
      */
     const mockGetRequest: jest.Mock = jest.fn().mockImplementation(() => ({
@@ -341,13 +352,12 @@ describe('HttpExceptionFilter', () => {
      *
      * This mock object provides stubbed methods to simulate the behavior of NestJS's `ArgumentsHost`,
      * allowing for controlled testing of exception filters and other components that depend on the host context.
-     *
-     * @property switchToHttp - Mocked method to simulate switching to HTTP context.
-     * @property getArgByIndex - Jest mock function to retrieve an argument by index.
-     * @property getArgs - Jest mock function to retrieve all arguments.
-     * @property getType - Jest mock function to retrieve the type of the context.
-     * @property switchToRpc - Mocked method to simulate switching to RPC context.
-     * @property switchToWs - Mocked method to simulate switching to WebSocket context.
+     * @property {() => mockHttpArgumentsHost} switchToHttp - Mocked method to simulate switching to HTTP context.
+     * @property {jest.Mock} getArgByIndex - Jest mock function to retrieve an argument by index.
+     * @property {jest.Mock} getArgs - Jest mock function to retrieve all arguments.
+     * @property {jest.Mock} getType - Jest mock function to retrieve the type of the context.
+     * @property {jest.Mock} switchToRpc - Mocked method to simulate switching to RPC context.
+     * @property {jest.Mock} switchToWs - Mocked method to simulate switching to WebSocket context.
      */
     const mockArgumentsHost: ArgumentsHost = {
       switchToHttp: mockHttpArgumentsHost,

--- a/src/common/http-exception.filter.ts
+++ b/src/common/http-exception.filter.ts
@@ -54,8 +54,9 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
   /**
    * The main entry point for the exception filter.
-   * @param exception - The exception that was thrown.
-   * @param host - The arguments host, providing access to request and response.
+   * @param {unknown} exception - The exception that was thrown.
+   * @param {ArgumentsHost} host - The arguments host, providing access to
+   *   request and response.
    */
   catch(exception: unknown, host: ArgumentsHost): void {
     const context = host.switchToHttp();
@@ -89,8 +90,9 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
   /**
    * Checks if an exception is an Express 'entity.too.large' error.
-   * @param exception - The exception to check.
-   * @returns True if the exception is a PayloadTooLargeError.
+   * @param {unknown} exception - The exception to check.
+   * @returns {exception is { type: string }} True if the exception is a
+   *   PayloadTooLargeError.
    */
   private isPayloadTooLargeError(
     exception: unknown,
@@ -105,8 +107,8 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
   /**
    * Handles the specific case of an Express PayloadTooLargeError.
-   * @param request - The incoming request object.
-   * @param response - The outgoing response object.
+   * @param {Request} request - The incoming request object.
+   * @param {Response} response - The outgoing response object.
    */
   private handlePayloadTooLargeError(
     request: Request,
@@ -121,9 +123,10 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
   /**
    * Handles the specific case of a ResourceExhaustedError.
-   * @param exception - The ResourceExhaustedError instance.
-   * @param request - The incoming request object.
-   * @param response - The outgoing response object.
+   * @param {ResourceExhaustedError} exception - The ResourceExhaustedError
+   *   instance.
+   * @param {Request} request - The incoming request object.
+   * @param {Response} response - The outgoing response object.
    */
   private handleResourceExhaustedError(
     exception: ResourceExhaustedError,
@@ -139,8 +142,8 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
   /**
    * Extracts error details (status, message, errors) from an exception.
-   * @param exception - The exception to process.
-   * @returns An object containing the structured error details.
+   * @param {unknown} exception - The exception to process.
+   * @returns {ErrorDetails} An object containing the structured error details.
    */
   private getErrorDetails(exception: unknown): ErrorDetails {
     if (exception instanceof HttpException) {
@@ -155,8 +158,8 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
   /**
    * Extracts details specifically from a NestJS HttpException.
-   * @param exception - The HttpException instance.
-   * @returns An object containing the structured error details.
+   * @param {HttpException} exception - The HttpException instance.
+   * @returns {ErrorDetails} An object containing the structured error details.
    */
   private getHttpExceptionDetails(exception: HttpException): ErrorDetails {
     const status = exception.getStatus();
@@ -197,10 +200,10 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
   /**
    * Logs the error with the appropriate level and context.
-   * @param status - The HTTP status code of the error.
-   * @param message - The error message to log.
-   * @param request - The incoming request object.
-   * @param exception - The original exception, used for stack traces.
+   * @param {number} status - The HTTP status code of the error.
+   * @param {string} message - The error message to log.
+   * @param {Request} request - The incoming request object.
+   * @param {unknown} exception - The original exception, used for stack traces.
    */
   private logError(
     status: number,
@@ -232,11 +235,11 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
   /**
    * Constructs and sends the final JSON error response.
-   * @param response - The outgoing response object.
-   * @param status - The HTTP status code.
-   * @param message - The error message.
-   * @param path - The request path.
-   * @param errors - Optional array of validation errors.
+   * @param {Response} response - The outgoing response object.
+   * @param {number} status - The HTTP status code.
+   * @param {string} message - The error message.
+   * @param {string} path - The request path.
+   * @param {ZodErrorDetail[]} [errors] - Optional array of validation errors.
    */
   private sendResponse(
     response: Response,
@@ -262,8 +265,10 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
   /**
    * Sanitises request headers to remove sensitive information before logging.
-   * @param headers - The original request headers.
-   * @returns A new object with redacted headers.
+   * @param {Record<string, string | string[] | undefined>} headers - The
+   *   original request headers.
+   * @returns {Record<string, string | string[]>} A new object with redacted
+   *   headers.
    */
   private sanitiseHeaders(
     headers: Record<string, string | string[] | undefined>,

--- a/src/common/json-parser.utility.ts
+++ b/src/common/json-parser.utility.ts
@@ -5,13 +5,11 @@ import { jsonrepair } from 'jsonrepair';
  * Utility class for parsing and repairing JSON strings.
  * This class attempts to repair malformed JSON strings using the `jsonrepair` library
  * and then parses them into JavaScript objects.
- *
  * @example
  * ```typescript
  * const jsonParser = new JsonParserUtility(new Logger('JsonParserUtility'));
  * const parsedObject = jsonParser.parse('```json\n{"key": "value"}\n```');
  * ```
- *
  * @throws {BadRequestException} Thrown when the provided JSON string is irreparable or malformed.
  */
 @Injectable()
@@ -39,10 +37,10 @@ export class JsonParserUtility {
    * Optionally trims content outside the first and last curly brackets.
    * If the parsed result is not an object or array (e.g., a string or number),
    * it is considered a failure, as the primary use case is for structured data.
-   *
-   * @param jsonString The raw string that may contain JSON.
-   * @param trim If true, trims content before the first '{' and after the last '}'. Defaults to true.
-   * @returns The parsed JavaScript object or array.
+   * @param {string} jsonString The raw string that may contain JSON.
+   * @param {boolean} trim If true, trims content before the first '{' and after
+   *   the last '}'. Defaults to true.
+   * @returns {unknown} The parsed JavaScript object or array.
    */
   parse(jsonString: string, trim = true): unknown {
     let processedString = jsonString;

--- a/src/common/pipes/image-validation.pipe.ts
+++ b/src/common/pipes/image-validation.pipe.ts
@@ -7,17 +7,13 @@ import { ConfigService } from '../../config/config.service';
 /**
  * A pipe for validating image uploads, ensuring they meet size and format requirements.
  * This pipe supports both binary image buffers and base64-encoded image strings.
- *
  * @class ImageValidationPipe
  * @implements {PipeTransform}
- *
- * @constructor
+ * @class
  * @param {ConfigService} configService - Service for accessing configuration values.
- *
- * @method transform
+ * @function transform
  * Validates the provided image data based on its type (Buffer or base64 string).
  * Throws a `BadRequestException` if the image fails validation.
- *
  * @param {unknown} value - The image data to validate. Can be a Buffer or a base64 string.
  * @returns {Promise<unknown>} - The validated image data, or the original value if validation passes.
  *

--- a/src/common/utils/log-redactor.utility.ts
+++ b/src/common/utils/log-redactor.utility.ts
@@ -15,11 +15,11 @@ export const LogRedactor = {
    * Creates a shallow copy of the incoming HTTP request and removes or masks
    * sensitive headers such as authorization tokens to prevent them from
    * appearing in log files.
-   *
-   * @param request - The incoming HTTP request
-   * @returns A cloned and redacted request object safe for logging
+   * @param {IncomingMessage} request - The incoming HTTP request.
+   * @returns {IncomingMessage} A cloned and redacted request object safe for
+   *   logging.
    */
-redactRequest(request: IncomingMessage): IncomingMessage {
+  redactRequest(request: IncomingMessage): IncomingMessage {
     // Shallow clone the request object
     const clonedRequest = Object.assign({}, request);
     // Clone headers to avoid mutating the original

--- a/src/common/utils/type-guards.ts
+++ b/src/common/utils/type-guards.ts
@@ -11,9 +11,9 @@
  *
  * Validates that the provided value is an object containing both 'system' and 'user'
  * properties that are both strings. This is commonly used for LLM prompt payloads.
- *
- * @param message - The value to check
- * @returns True if the value matches the expected system-user message structure
+ * @param {unknown} message - The value to check.
+ * @returns {message is { system: string; user: string }} True if the value
+ *   matches the expected system-user message structure.
  */
 export function isSystemUserMessage(
   message: unknown,

--- a/src/common/zod-validation.pipe.ts
+++ b/src/common/zod-validation.pipe.ts
@@ -10,7 +10,6 @@ import type { ZodType } from 'zod';
 /**
  * A custom validation pipe that uses Zod schemas to validate incoming data.
  * This pipe is designed to be used with NestJS and implements the `PipeTransform` interface.
- *
  * @example
  * ```typescript
  * const schema = z.object({
@@ -19,23 +18,19 @@ import type { ZodType } from 'zod';
  * });
  * const validationPipe = new ZodValidationPipe(schema);
  * ```
- *
  * @remarks
  * - If the schema is not provided, the pipe will simply return the input value without validation.
  * - In production mode, validation errors are masked with a generic message for security purposes.
  * - In non-production mode, detailed validation issues are logged and returned.
- *
- * @constructor
+ * @class
  * @param schema - The Zod schema used for validation.
- *
- * @method transform
+ * @function transform
  * Validates the input value against the provided Zod schema.
  * If validation fails, it throws a `BadRequestException` with the validation errors.
- *
  * @param value - The value to be validated.
  * @param metadata - Metadata about the argument being processed.
  * @returns The parsed value if validation succeeds.
- * @throws `BadRequestException` if validation fails.
+ * @throws {BadRequestException} If validation fails.
  */
 @Injectable()
 export class ZodValidationPipe implements PipeTransform {

--- a/src/config/config.environment-example.spec.ts
+++ b/src/config/config.environment-example.spec.ts
@@ -52,7 +52,7 @@ describe('.env.example file', () => {
       return `
 NODE_ENV=development
 PORT=3000
-APP_NAME=AssessmentBot-Backend
+APP_NAME=Assessment Bot LLM Service
 APP_VERSION=1.0.0
 DATABASE_URL=your_database_url_here
 API_KEY=your_api_key_here
@@ -88,7 +88,7 @@ API_KEY=your_api_key_here
 
     expect(exampleConfig.NODE_ENV).toBe('development');
     expect(exampleConfig.PORT).toBe('3000');
-    expect(exampleConfig.APP_NAME).toBe('AssessmentBot-Backend');
+    expect(exampleConfig.APP_NAME).toBe('Assessment Bot LLM Service');
     expect(exampleConfig.APP_VERSION).toBe('1.0.0');
   });
 });

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -5,12 +5,10 @@ import { ConfigService } from './config.service';
 
 /**
  * @module ConfigModule
- *
  * @description
  * This module is responsible for providing the application's configuration services.
  * It imports the underlying `NestConfigModule` to handle the loading of `.env` files but only exports
  * our custom, validation-aware `ConfigService`.
- *
  * @remarks
  * **Architectural Reasoning:**
  * This module acts as a boundary, ensuring that the rest of the application interacts only with our

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -232,7 +232,7 @@ describe('ConfigService', () => {
     it('APP_NAME should return default value when not set', () => {
       delete process.env.APP_NAME;
       const configService = new ConfigService();
-      expect(configService.get('APP_NAME')).toBe('AssessmentBot-Backend');
+      expect(configService.get('APP_NAME')).toBe('Assessment Bot LLM Service');
     });
 
     it('APP_VERSION should be optional and return undefined', () => {
@@ -331,7 +331,7 @@ describe('ConfigService', () => {
           return `
 NODE_ENV=development
 PORT=3000
-APP_NAME=AssessmentBot-Backend
+APP_NAME=Assessment Bot LLM Service
 APP_VERSION=1.0.0
 DATABASE_URL=your_database_url_here
 API_KEY=your_api_key_here

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -9,12 +9,10 @@ import { configSchema, type Config } from './environment.schema';
 
 /**
  * @class ConfigService
- *
  * @description
  * This service is the single source of truth for all **runtime** environment configuration in the application.
  * It is responsible for loading environment variables from `.env` files and `process.env`, validating them against
  * the centralized `configSchema`, and making them available to the rest of the application through a clean, injectable service.
- *
  * @remarks
  * **Architectural Reasoning:**
  * - **Centralisation:** All configuration access is channelled through this service, preventing configuration sprawl
@@ -28,7 +26,6 @@ import { configSchema, type Config } from './environment.schema';
  * **Usage:**
  * This service should be injected into any module that requires access to configuration values at runtime.
  * For configuration needed at **compile time** (e.g., in decorators), see `throttler.config.ts`.
- *
  * @see environment.schema.ts - For the source of truth on validation rules.
  * @see throttler.config.ts - For an example of compile-time configuration.
  */
@@ -40,8 +37,12 @@ export class ConfigService {
     let loadedEnvironment = {};
 
     // Determine which env file to load based on NODE_ENV
-    const environmentFileName = process.env.NODE_ENV === 'test' ? '.test.env' : '.env';
-    const environmentFilePath = path.resolve(process.cwd(), environmentFileName);
+    const environmentFileName =
+      process.env.NODE_ENV === 'test' ? '.test.env' : '.env';
+    const environmentFilePath = path.resolve(
+      process.cwd(),
+      environmentFileName,
+    );
 
     // envFilePath is constructed from cwd and a fixed filename, safe to use
     // eslint-disable-next-line security/detect-non-literal-fs-filename
@@ -66,8 +67,8 @@ export class ConfigService {
 
   /**
    * Retrieves a configuration value by its key.
-   * @param key The key of the configuration value to retrieve.
-   * @returns The typed configuration value.
+   * @param {T} key The key of the configuration value to retrieve.
+   * @returns {Config[T]} The typed configuration value.
    */
   get<T extends keyof Config>(key: T): Config[T] {
     // `key` is constrained to validated schema keys, so this access is not user-controlled.
@@ -76,9 +77,9 @@ export class ConfigService {
   }
 
   /**
-   * Calculates the global payload limit for the application based on the max image upload size.
-   * This is used to configure the `body-parser` middleware.
-   * @returns A string representing the payload limit (e.g., '9mb').
+   * Calculates the global payload limit for the application based on the max
+   * image upload size. This is used to configure the `body-parser` middleware.
+   * @returns {string} A string representing the payload limit (e.g., '9mb').
    */
   getGlobalPayloadLimit(): string {
     const maxImageSizeMB = this.config.MAX_IMAGE_UPLOAD_SIZE_MB;

--- a/src/config/environment.schema.ts
+++ b/src/config/environment.schema.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 /**
  * @file Defines the Zod schema for environment variables, serving as the single source of truth for configuration validation.
- *
  * @remarks
  * This schema is crucial for ensuring that the application starts with a valid and type-safe configuration.
  * It is used in two key places:
@@ -18,7 +17,6 @@ import { z } from 'zod';
 
 /**
  * The Zod schema for validating and transforming all environment variables for the application.
- *
  * @property {string} NODE_ENV - The application environment (e.g., 'development', 'production', 'test').
  * @property {number} PORT - The port on which the server will run.
  * @property {string} APP_NAME - The name of the application.

--- a/src/config/environment.schema.ts
+++ b/src/config/environment.schema.ts
@@ -37,7 +37,7 @@ import { z } from 'zod';
 export const configSchema = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']).default('production'),
   PORT: z.coerce.number().int().min(1).max(65535).default(3000),
-  APP_NAME: z.string().default('AssessmentBot-Backend'),
+  APP_NAME: z.string().default('Assessment Bot LLM Service'),
   APP_VERSION: z.string().optional(),
   API_KEYS: z
     .string()

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,5 @@
 /**
  * @file Barrel file for the configuration module.
- *
  * @remarks
  * This file re-exports the essential public-facing components of the configuration module,
  * making them easier to import into other parts of the application.

--- a/src/config/throttler.config.ts
+++ b/src/config/throttler.config.ts
@@ -4,7 +4,6 @@ import { configSchema } from './environment.schema';
 
 /**
  * @file Configures the application's rate-limiting (throttling) settings.
- *
  * @remarks
  * This file provides the configuration for the `@nestjs/throttler` module.
  * A key architectural decision here is to parse environment variables directly at compile time.
@@ -26,7 +25,8 @@ const validatedEnvironment = configSchema.parse(process.env);
 
 // 2. Extract the validated throttler values into constants.
 const throttlerTtl = validatedEnvironment.THROTTLER_TTL;
-const unauthenticatedLimit = validatedEnvironment.UNAUTHENTICATED_THROTTLER_LIMIT;
+const unauthenticatedLimit =
+  validatedEnvironment.UNAUTHENTICATED_THROTTLER_LIMIT;
 const authenticatedLimit = validatedEnvironment.AUTHENTICATED_THROTTLER_LIMIT;
 
 /**

--- a/src/llm/gemini.service.ts
+++ b/src/llm/gemini.service.ts
@@ -35,17 +35,20 @@ export class GeminiService extends LLMService {
   }
 
   /**
-   * Internal method that sends a payload to the Gemini API to generate an assessment.
-   * This method is called by the base class's send method, which handles retry logic.
+   * Internal method that sends a payload to the Gemini API to generate an
+   * assessment.
    *
-   * This method dynamically selects the appropriate Gemini model based on the payload type
-   * (text-only or multimodal with images). It attempts to repair malformed JSON
-   * in the response and validates the final structure against the LlmResponseSchema.
-   *
-   * @param payload The LlmPayload containing the prompt and any associated data.
-   * @returns A Promise that resolves to a validated LlmResponse object.
-   * @throws ZodError if the response validation fails.
-   * @throws Error if the API call fails or the response is invalid.
+   * This method is called by the base class's send method, which handles retry
+   * logic. It dynamically selects the appropriate Gemini model based on the
+   * payload type (text-only or multimodal with images). It attempts to repair
+   * malformed JSON in the response and validates the final structure against
+   * the LlmResponseSchema.
+   * @param {LlmPayload} payload The LlmPayload containing the prompt and any
+   *   associated data.
+   * @returns {Promise<LlmResponse>} A Promise that resolves to a validated
+   *   LlmResponse object.
+   * @throws {ZodError} If the response validation fails.
+   * @throws {Error} If the API call fails or the response is invalid.
    */
   protected async _sendInternal(payload: LlmPayload): Promise<LlmResponse> {
     const modelParameters: GeminiModelParameters =
@@ -86,8 +89,9 @@ export class GeminiService extends LLMService {
 
   /**
    * Type guard to check if the payload is for an image prompt.
-   * @param payload The payload to check.
-   * @returns True if the payload is an ImagePromptPayload.
+   * @param {LlmPayload} payload The payload to check.
+   * @returns {payload is ImagePromptPayload} True if the payload is an
+   *   ImagePromptPayload.
    */
   private isImagePromptPayload(
     payload: LlmPayload,
@@ -97,8 +101,9 @@ export class GeminiService extends LLMService {
 
   /**
    * Type guard to check if the payload is for a string prompt.
-   * @param payload The payload to check.
-   * @returns True if the payload is a StringPromptPayload.
+   * @param {LlmPayload} payload The payload to check.
+   * @returns {payload is StringPromptPayload} True if the payload is a
+   *   StringPromptPayload.
    */
   private isStringPromptPayload(
     payload: LlmPayload,
@@ -108,11 +113,12 @@ export class GeminiService extends LLMService {
 
   /**
    * Builds the model parameters for the Gemini API call.
+   *
    * Selects the appropriate Gemini model based on payload type:
    * - Image prompts use gemini-2.5-flash (full multimodal capabilities)
-   * - Text/Table prompts use gemini-2.5-flash-lite (optimised for text-only)
-   * @param payload The LlmPayload to be sent.
-   * @returns The configured ModelParams object.
+   * - Text/Table prompts use gemini-2.5-flash-lite (optimised for text-only).
+   * @param {LlmPayload} payload The LlmPayload to be sent.
+   * @returns {GeminiModelParameters} The configured ModelParams object.
    */
   private buildModelParams(payload: LlmPayload): GeminiModelParameters {
     // Select model based on payload type
@@ -140,8 +146,8 @@ export class GeminiService extends LLMService {
 
   /**
    * Builds the contents for the Gemini API call.
-   * @param payload The LlmPayload to be sent.
-   * @returns An array of strings or Parts for the API call.
+   * @param {LlmPayload} payload The LlmPayload to be sent.
+   * @returns {(string | Part)[]} An array of strings or Parts for the API call.
    */
   private buildContents(payload: LlmPayload): (string | Part)[] {
     if (this.isImagePromptPayload(payload)) {
@@ -159,9 +165,11 @@ export class GeminiService extends LLMService {
   }
 
   /**
-   * Helper to map image payloads to Gemini API parts, ensuring the prompt follows the correct structure.
-   * @param images An array of image objects.
-   * @returns An array of Parts for the Gemini API.
+   * Helper to map image payloads to Gemini API parts, ensuring the prompt
+   * follows the correct structure.
+   * @param {Array<{ mimeType: string; data?: string; uri?: string }>} images
+   *   An array of image objects.
+   * @returns {Part[]} An array of Parts for the Gemini API.
    */
   private mapImageParts(
     images: Array<{ mimeType: string; data?: string; uri?: string }>,
@@ -202,11 +210,14 @@ export class GeminiService extends LLMService {
   }
 
   /**
-   * Logs the payload being sent to Gemini, with different logging strategies based on payload type.
-   * For StringPromptPayload: logs the full contents
-   * For ImagePromptPayload: logs only the length of contents to avoid logging large image data
-   * @param payload The original payload being sent
-   * @param contents The processed contents array
+   * Logs the payload being sent to Gemini, with different logging strategies
+   * based on payload type.
+   *
+   * For StringPromptPayload: logs the full contents.
+   * For ImagePromptPayload: logs only the length of contents to avoid logging
+   * large image data.
+   * @param {LlmPayload} payload The original payload being sent.
+   * @param {(string | Part)[]} contents The processed contents array.
    */
   private logPayload(payload: LlmPayload, contents: (string | Part)[]): void {
     if (this.isStringPromptPayload(payload)) {

--- a/src/llm/llm.module.spec.ts
+++ b/src/llm/llm.module.spec.ts
@@ -33,9 +33,8 @@ const mockConfigService = {
  * parsing a JSON string into a JavaScript object. The `parse` method is
  * implemented using Jest's `fn` to allow tracking calls and providing custom
  * behavior during tests.
- *
- * @property parse - A Jest mock function that takes a JSON string as input
- * and returns the parsed JavaScript object.
+ * @property {jest.Mock} parse - A Jest mock function that takes a JSON string
+ * as input and returns the parsed JavaScript object.
  */
 const mockJsonParserUtility = {
   parse: jest.fn((jsonString: string) => {

--- a/src/llm/llm.module.ts
+++ b/src/llm/llm.module.ts
@@ -9,19 +9,18 @@ import { ConfigModule } from '../config/config.module';
  * The `LlmModule` is a NestJS module responsible for configuring and providing
  * services related to Large Language Models (LLMs). It imports necessary modules
  * and defines providers and exports for dependency injection.
- *
  * @module LlmModule
  *
- * @imports
+ * **imports:**
  * - `ConfigModule`: Handles application configuration.
  * - `CommonModule`: Provides shared functionality across the application.
  *
- * @providers
+ * **providers:**
  * - `GeminiService`: A service implementation for LLM-related operations.
  * - `{ provide: LLMService, useClass: GeminiService }`: Maps the `LLMService` token
  *   to the `GeminiService` implementation for dependency injection.
  *
- * @exports
+ * **exports:**
  * - `LLMService`: Makes the `LLMService` available for other modules.
  */
 @Module({

--- a/src/llm/llm.service.interface.ts
+++ b/src/llm/llm.service.interface.ts
@@ -15,7 +15,7 @@ export type StringPromptPayload = {
   system: string;
   /** The user-provided prompt or question. */
   user: string;
-  /** Optional temperature for sampling (default: 0) */
+  /** Optional temperature for sampling (default: 0). */
   temperature?: number;
 };
 
@@ -29,7 +29,7 @@ export type ImagePromptPayload = {
   images: Array<{ mimeType: string; data?: string; uri?: string }>;
   /** Optional messages array. */
   messages?: Array<{ content: string }>;
-  /** Optional temperature for sampling (default: 0) */
+  /** Optional temperature for sampling (default: 0). */
   temperature?: number;
 };
 
@@ -51,14 +51,17 @@ export abstract class LLMService {
 
   /**
    * Sends a payload to the LLM provider to generate an assessment.
-   * This method includes automatic retry logic with exponential backoff for 429 rate limit errors.
-   * Resource exhausted errors (quota exceeded) are not retried and bubble up immediately.
    *
-   * @param payload The content to be sent to the LLM. This can be a simple string
-   * or a complex object for multimodal inputs (e.g., text and images).
-   * The payload may include an optional `temperature` parameter (default: 0).
-   * @returns A Promise that resolves to a validated LlmResponse object.
-   * @throws ResourceExhaustedError if the API quota has been exceeded.
+   * This method includes automatic retry logic with exponential backoff for
+   * 429 rate limit errors. Resource exhausted errors (quota exceeded) are not
+   * retried and bubble up immediately.
+   * @param {LlmPayload} payload The content to be sent to the LLM. This can be
+   *   a simple string or a complex object for multimodal inputs (e.g., text and
+   *   images). The payload may include an optional `temperature` parameter
+   *   (default: 0).
+   * @returns {Promise<LlmResponse>} A Promise that resolves to a validated
+   *   LlmResponse object.
+   * @throws {ResourceExhaustedError} If the API quota has been exceeded.
    */
   async send(payload: LlmPayload): Promise<LlmResponse> {
     const maxRetries = this.configService.get('LLM_MAX_RETRIES');
@@ -187,20 +190,26 @@ export abstract class LLMService {
   }
 
   /**
-   * Internal method that subclasses must implement to handle the actual LLM API call.
-   * This method should not include retry logic, as that is handled by the base class.
+   * Internal method that subclasses must implement to handle the actual LLM
+   * API call.
    *
-   * @param payload The LlmPayload to be sent to the specific LLM provider.
-   * @returns A Promise that resolves to a validated LlmResponse object.
+   * This method should not include retry logic, as that is handled by the base
+   * class.
+   * @param {LlmPayload} payload The LlmPayload to be sent to the specific LLM
+   *   provider.
+   * @returns {Promise<LlmResponse>} A Promise that resolves to a validated
+   *   LlmResponse object.
    */
   protected abstract _sendInternal(payload: LlmPayload): Promise<LlmResponse>;
 
   /**
-   * Checks if an error is a resource exhausted error (HTTP 429 with specific patterns).
-   * Resource exhausted errors indicate API quota limits have been reached and should
-   * not be retried.
-   * @param error The error to check.
-   * @returns True if the error is a resource exhausted error.
+   * Checks if an error is a resource exhausted error (HTTP 429 with specific
+   * patterns).
+   *
+   * Resource exhausted errors indicate API quota limits have been reached and
+   * should not be retried.
+   * @param {unknown} error The error to check.
+   * @returns {boolean} True if the error is a resource exhausted error.
    */
   private isResourceExhaustedError(error: unknown): boolean {
     // Use the utility function to extract status code from various error formats
@@ -228,10 +237,9 @@ export abstract class LLMService {
   }
 
   /**
-   * Checks if an error is a rate limit error (HTTP 429) that should be retried.
-   * This method excludes resource exhausted errors which should not be retried.
-   * @param error The error to check.
-   * @returns True if the error is a retryable rate limit error.
+   * Checks if a value is an Error object.
+   * @param {unknown} error The value to check.
+   * @returns {error is Error} True if the value is an Error object.
    */
   protected isErrorObject(error: unknown): error is Error {
     return (
@@ -267,9 +275,11 @@ export abstract class LLMService {
 
   /**
    * Utility function to extract HTTP status code from various error formats.
+   *
    * This is designed to work with different LLM SDK error structures.
-   * @param error The error to extract status code from.
-   * @returns The HTTP status code if found, undefined otherwise.
+   * @param {unknown} error The error to extract status code from.
+   * @returns {number | undefined} The HTTP status code if found, undefined
+   *   otherwise.
    */
   private extractErrorStatusCode(error: unknown): number | undefined {
     if (!error || typeof error !== 'object') {
@@ -302,7 +312,8 @@ export abstract class LLMService {
 
   /**
    * Utility method to sleep for a specified duration.
-   * @param ms The number of milliseconds to sleep.
+   * @param {number} ms - The number of milliseconds to sleep.
+   * @returns {Promise<void>} A promise that resolves after the specified delay.
    */
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/llm/llm.service.interface.ts
+++ b/src/llm/llm.service.interface.ts
@@ -250,6 +250,14 @@ export abstract class LLMService {
     );
   }
 
+  /**
+   * Determines whether an error represents a retryable rate limit condition.
+   * Checks for HTTP 429 status codes and message patterns like
+   * 'rate limit' or 'too many requests'. Resource exhausted errors (non-retryable)
+   * are explicitly excluded.
+   * @param error - The error to check.
+   * @returns True if the error indicates a retryable rate limit.
+   */
   private isRateLimitError(error: unknown): boolean {
     // First check if it's a resource exhausted error - those shouldn't be retried
     if (this.isResourceExhaustedError(error)) {

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -15,9 +15,10 @@ export type AssessmentCriterion = z.infer<typeof AssessmentCriterionSchema>;
  *
  * Defines the structure and validation rules for individual assessment
  * criteria used in LLM-generated assessments.
- *
- * @property score - Integer between 0 and 5 representing the assessment score
- * @property reasoning - Non-empty string explaining the rationale for the score
+ * @property {number} score - Integer between 0 and 5 representing the
+ *   assessment score.
+ * @property {string} reasoning - Non-empty string explaining the rationale for
+ *   the score.
  */
 export const AssessmentCriterionSchema = z.object({
   score: z.number().int().min(0).max(5),
@@ -30,10 +31,12 @@ export const AssessmentCriterionSchema = z.object({
  * This schema ensures that LLM responses conform to the expected structure
  * with exactly three assessment criteria: completeness, accuracy, and SPAG
  * (Spelling, Punctuation, and Grammar).
- *
- * @property completeness - Assessment of how complete the response is
- * @property accuracy - Assessment of the factual accuracy of the response
- * @property spag - Assessment of spelling, punctuation, and grammar quality
+ * @property {AssessmentCriterion} completeness - Assessment of how complete
+ *   the response is.
+ * @property {AssessmentCriterion} accuracy - Assessment of the factual accuracy
+ *   of the response.
+ * @property {AssessmentCriterion} spag - Assessment of spelling, punctuation,
+ *   and grammar quality.
  */
 export const LlmResponseSchema = z.object({
   completeness: AssessmentCriterionSchema,

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,9 @@ import process from 'node:process';
 
 import * as dotenv from 'dotenv';
 
+/**
+ * Start the production application.
+ */
 export async function start(): Promise<void> {
   dotenv.config({ path: '.env' });
   const { bootstrap } = await import('./bootstrap');
@@ -30,6 +33,11 @@ if (isRunningDirectly()) {
   })();
 }
 
+/**
+ * Check whether the current module is the main entry point.
+ * @returns {boolean} True if the module is the main entry point and not running
+ *   under Jest.
+ */
 function isRunningDirectly(): boolean {
   return (
     typeof require !== 'undefined' &&

--- a/src/prompt/image.prompt.ts
+++ b/src/prompt/image.prompt.ts
@@ -22,8 +22,8 @@ export class ImagePrompt extends Prompt {
    * Image prompts handle content differently from text prompts and
    * typically don't require separate user message parts since the
    * images are included directly in the payload.
-   *
-   * @returns Promise resolving to an empty array of Parts
+   * @returns {Promise<import('@google/generative-ai').Part[]>} Promise
+   *   resolving to an empty array of Parts.
    */
   protected async buildUserMessageParts(): Promise<
     import('@google/generative-ai').Part[]
@@ -35,11 +35,14 @@ export class ImagePrompt extends Prompt {
 
   /**
    * Initialises the ImagePrompt instance with image-specific configuration.
-   *
-   * @param inputs - Validated prompt input data containing image information
-   * @param logger - Logger instance for recording image prompt operations
-   * @param images - Optional array of image objects with file paths and MIME types
-   * @param systemPrompt - Optional system prompt string providing context for image assessment
+   * @param {PromptInput} inputs - Validated prompt input data containing image
+   *   information.
+   * @param {Logger} logger - Logger instance for recording image prompt
+   *   operations.
+   * @param {{ path: string; mimeType: string }[]} [images] - Optional array of
+   *   image objects with file paths and MIME types.
+   * @param {string} [systemPrompt] - Optional system prompt string providing
+   *   context for image assessment.
    */
   constructor(
     inputs: PromptInput,
@@ -57,9 +60,9 @@ export class ImagePrompt extends Prompt {
    * Creates a payload suitable for multimodal LLMs that can process both
    * text and images. The method handles two scenarios:
    * 1. File-based images: reads image files from disk
-   * 2. Data URI images: extracts image data from base64 encoded strings
-   *
-   * @returns Promise resolving to an LlmPayload containing system prompt and image data
+   * 2. Data URI images: extracts image data from base64 encoded strings.
+   * @returns {Promise<LlmPayload>} Promise resolving to an LlmPayload
+   *   containing system prompt and image data.
    */
   public async buildMessage(): Promise<LlmPayload> {
     // For image prompts, the user message is a combination of the rendered system prompt
@@ -94,8 +97,8 @@ export class ImagePrompt extends Prompt {
    * Reads image files from disk and converts them to base64 format
    * suitable for LLM processing. This method is used when images
    * are provided as file references rather than embedded data.
-   *
-   * @returns Promise resolving to array of image data and MIME type objects
+   * @returns {Promise<{ data: string; mimeType: string }[]>} Promise resolving
+   *   to array of image data and MIME type objects.
    */
   private async buildImagesFromFiles(): Promise<
     { data: string; mimeType: string }[]
@@ -116,9 +119,9 @@ export class ImagePrompt extends Prompt {
    * Extracts base64-encoded image data from data URI strings in the
    * input fields. This method assumes the validation pipeline has
    * already confirmed all image fields contain valid data URIs.
-   *
-   * @returns Array of image data and MIME type objects
-   * @throws Error if any data URI is malformed
+   * @returns {{ data: string; mimeType: string }[]} Array of image data and
+   *   MIME type objects.
+   * @throws {Error} If any data URI is malformed.
    */
   private buildImagesFromDataUris(): { data: string; mimeType: string }[] {
     // Assumes validation pipeline guarantees all three tasks are valid data URIs
@@ -145,18 +148,18 @@ export class ImagePrompt extends Prompt {
 
   /**
    * Reads an image file from the specified path and returns its content as a base64-encoded string.
-   *
-   * @param imagePath - The relative path to the image file within the allowed directory.
-   *                    Path traversal is blocked to ensure security.
-   * @param mimeType - The MIME type of the image file. Must be one of the allowed MIME types
-   *                   specified in the `ALLOWED_IMAGE_MIME_TYPES` environment variable.
-   *                   Defaults to 'image/png' if not provided.
-   * @returns A promise that resolves to the base64-encoded content of the image file.
-   *
+   * @param {string} imagePath - The relative path to the image file within the
+   *   allowed directory. Path traversal is blocked to ensure security.
+   * @param {string} [mimeType] - The MIME type of the image file. Must be one
+   *   of the allowed MIME types specified in the `ALLOWED_IMAGE_MIME_TYPES`
+   *   environment variable. Defaults to 'image/png' if not provided.
+   * @returns {Promise<string>} A promise that resolves to the base64-encoded
+   *   content of the image file.
    * @throws {Error} If the `imagePath` contains path traversal (`..`).
-   * @throws {Error} If the `mimeType` is not allowed based on the environment configuration.
-   * @throws {Error} If the resolved file path is outside the authorized directory.
-   *
+   * @throws {Error} If the `mimeType` is not allowed based on the environment
+   *   configuration.
+   * @throws {Error} If the resolved file path is outside the authorised
+   *   directory.
    * @remarks
    * - The method ensures security by validating the file path and MIME type before reading the file.
    * - The base directory for image files is restricted to `docs/ImplementationPlan/Stage6/Prompts`.

--- a/src/prompt/prompt.base.ts
+++ b/src/prompt/prompt.base.ts
@@ -13,11 +13,11 @@ import { LlmPayload } from '../llm/llm.service.interface';
  * empty task template.
  */
 export const PromptInputSchema = z.object({
-  /** The reference or model solution for the task */
+  /** The reference or model solution for the task. */
   referenceTask: z.string(),
-  /** The student's submitted response to the task */
+  /** The student's submitted response to the task. */
   studentTask: z.string(),
-  /** The original task prompt or template given to the student */
+  /** The original task prompt or template given to the student. */
   emptyTask: z.string(),
 });
 
@@ -32,11 +32,10 @@ export type PromptInput = z.infer<typeof PromptInputSchema>;
  * This class provides common functionality for prompt generation including:
  * - Input validation using Zod schemas
  * - Template loading and rendering with Mustache
- * - Common properties and lifecycle management
+ * - Common properties and lifecycle management.
  *
  * Subclasses must implement the `buildMessage` method to create
  * task-specific LLM payloads appropriate for their assessment type.
- *
  * @abstract
  */
 export abstract class Prompt {
@@ -54,12 +53,14 @@ export abstract class Prompt {
    * This constructor validates the provided inputs against the schema,
    * stores the validated data as instance properties, and configures
    * the prompt with template and system prompt information.
-   *
-   * @param inputs - Raw input data to be validated against PromptInputSchema
-   * @param logger - Logger instance for recording prompt operations
-   * @param userTemplateName - Optional name of the markdown template for user message parts
-   * @param systemPrompt - Optional system prompt string for LLM context
-   * @throws Error if input validation fails
+   * @param {unknown} inputs - Raw input data to be validated against
+   *   PromptInputSchema.
+   * @param {Logger} logger - Logger instance for recording prompt operations.
+   * @param {string} [userTemplateName] - Optional name of the markdown
+   *   template for user message parts.
+   * @param {string} [systemPrompt] - Optional system prompt string for LLM
+   *   context.
+   * @throws {Error} If input validation fails.
    */
   constructor(
     inputs: unknown,
@@ -84,7 +85,7 @@ export abstract class Prompt {
 
   /**
    * Logs the length of each input element at info level.
-   * @param inputs The validated PromptInput object.
+   * @param {PromptInput} inputs The validated PromptInput object.
    */
   private logInputLengths(inputs: PromptInput): void {
     const lengths = [
@@ -97,9 +98,10 @@ export abstract class Prompt {
 
   /**
    * Renders a template string using mustache with the provided data.
-   * @param template The template string to render.
-   * @param data A record of key-value pairs to substitute in the template.
-   * @returns The rendered string.
+   * @param {string} template The template string to render.
+   * @param {Record<string, string>} data A record of key-value pairs to
+   *   substitute in the template.
+   * @returns {string} The rendered string.
    */
   protected render(template: string, data: Record<string, string>): string {
     this.logger.debug(
@@ -118,14 +120,10 @@ export abstract class Prompt {
 
   /**
    * Builds the final payload to be sent to the LLM service.
-   * This method must be implemented by all subclasses.
-   * @returns A Promise that resolves to the LlmPayload.
-   */
-  /**
-   * Builds the final payload to be sent to the LLM service.
+   *
    * This is the default implementation for text and table prompts.
    * Subclasses can override if needed (e.g., ImagePrompt).
-   * @returns A Promise that resolves to the LlmPayload.
+   * @returns {Promise<LlmPayload>} A Promise that resolves to the LlmPayload.
    */
   public async buildMessage(): Promise<LlmPayload> {
     this.logger.debug(`Building message for ${this.constructor.name}`);

--- a/src/prompt/prompt.factory.ts
+++ b/src/prompt/prompt.factory.ts
@@ -23,17 +23,19 @@ export class PromptFactory {
   private readonly logger = new Logger(PromptFactory.name);
 
   /**
-   * Creates an appropriate prompt instance based on the provided assessment data.
+   * Creates an appropriate prompt instance based on the provided assessment
+   * data.
    *
    * This method orchestrates the creation of task-specific prompts by:
    * 1. Extracting input data from the DTO
    * 2. Determining the correct prompt template files
    * 3. Loading system prompts from markdown files
-   * 4. Instantiating the appropriate prompt subclass
-   *
-   * @param dto - Data transfer object containing task type and assessment data
-   * @returns A promise resolving to a task-specific prompt instance
-   * @throws Error if the task type is unsupported
+   * 4. Instantiating the appropriate prompt subclass.
+   * @param {CreateAssessorDto} dto - Data transfer object containing task type
+   *   and assessment data.
+   * @returns {Promise<Prompt>} A promise resolving to a task-specific prompt
+   *   instance.
+   * @throws {Error} If the task type is unsupported.
    */
   public async create(dto: CreateAssessorDto): Promise<Prompt> {
     this.logger.log(`Creating prompt for task type: ${dto.taskType}.`);
@@ -72,10 +74,10 @@ export class PromptFactory {
    * Different task types require different prompt templates for optimal
    * LLM performance. This method maps task types to their corresponding
    * system and user prompt template files.
-   *
-   * @param taskType - The type of assessment task
-   * @returns Object containing the names of system and user prompt template files
-   * @throws Error if the task type is not supported
+   * @param {TaskType} taskType - The type of assessment task.
+   * @returns {{ systemPromptFile?: string; userTemplateFile?: string }} Object
+   *   containing the names of system and user prompt template files.
+   * @throws {Error} If the task type is not supported.
    */
   private getPromptFiles(taskType: TaskType): {
     systemPromptFile?: string;
@@ -108,9 +110,10 @@ export class PromptFactory {
    * System prompts provide the LLM with context and instructions for
    * how to approach the assessment task. This method safely loads
    * the content from markdown files in the templates directory.
-   *
-   * @param systemPromptFile - Name of the system prompt markdown file
-   * @returns Promise resolving to the prompt content, or undefined if no file specified
+   * @param {string} [systemPromptFile] - Name of the system prompt markdown
+   *   file.
+   * @returns {Promise<string | undefined>} Promise resolving to the prompt
+   *   content, or undefined if no file specified.
    */
   private async loadSystemPrompt(
     systemPromptFile?: string,
@@ -139,13 +142,13 @@ export class PromptFactory {
    * This method creates the specific prompt implementation (TextPrompt,
    * TablePrompt, or ImagePrompt) with the appropriate configuration
    * for the given task type and input data.
-   *
-   * @param dto - The assessment data transfer object
-   * @param inputs - Validated prompt input data
-   * @param userTemplateFile - Name of the user template file (if applicable)
-   * @param systemPrompt - System prompt content (if applicable)
-   * @returns Configured prompt instance ready for message generation
-   * @throws Error if the task type is not supported
+   * @param {CreateAssessorDto} dto - The assessment data transfer object.
+   * @param {unknown} inputs - Validated prompt input data.
+   * @param {string} [userTemplateFile] - Name of the user template file (if
+   *   applicable).
+   * @param {string} [systemPrompt] - System prompt content (if applicable).
+   * @returns {Prompt} Configured prompt instance ready for message generation.
+   * @throws {Error} If the task type is not supported.
    */
   private instantiatePrompt(
     dto: CreateAssessorDto,

--- a/src/prompt/prompt.module.ts
+++ b/src/prompt/prompt.module.ts
@@ -8,14 +8,13 @@ import { PromptFactory } from './prompt.factory';
  * This module provides the infrastructure for creating and managing prompts
  * that are sent to Large Language Models. It includes factory patterns for
  * generating different types of prompts based on task requirements.
- *
  * @module PromptModule
  *
- * @providers
+ * **providers:**
  * - `PromptFactory`: Factory for creating task-specific prompt instances
  * - `Logger`: Logging functionality for prompt operations
  *
- * @exports
+ * **exports:**
  * - `PromptFactory`: Makes the factory available to other modules
  */
 @Module({

--- a/src/prompt/table.prompt.spec.ts
+++ b/src/prompt/table.prompt.spec.ts
@@ -15,6 +15,11 @@ jest.mock('node:fs/promises', () => ({
 
 const mockedReadFile = jest.mocked(readFile);
 
+/**
+ * Normalise a file path argument to a string.
+ * @param {PathLike | FileHandle} filePath - The file path to normalise.
+ * @returns {string} The normalised file path as a string.
+ */
 function normaliseFilePath(filePath: PathLike | FileHandle): string {
   if (typeof filePath === 'string') return filePath;
   if (Buffer.isBuffer(filePath)) return filePath.toString('utf8');
@@ -23,6 +28,11 @@ function normaliseFilePath(filePath: PathLike | FileHandle): string {
   throw new Error('File handle paths are not supported in this test');
 }
 
+/**
+ * Get the template content for a given file path.
+ * @param {PathLike | FileHandle} filePath - The file path to look up.
+ * @returns {string} The template content string.
+ */
 function getTemplateContent(filePath: PathLike | FileHandle): string {
   const filePathString = normaliseFilePath(filePath);
   if (filePathString.includes('table.system.prompt.md')) return systemTemplate;

--- a/src/prompt/table.prompt.ts
+++ b/src/prompt/table.prompt.ts
@@ -12,11 +12,14 @@ import { Prompt } from './prompt.base';
 export class TablePrompt extends Prompt {
   /**
    * Initialises the TablePrompt instance with table-specific configuration.
-   *
-   * @param inputs - Raw input data to be validated containing table information
-   * @param logger - Logger instance for recording table prompt operations
-   * @param userTemplateName - Optional name of the user template file (defaults to table template)
-   * @param systemPrompt - Optional system prompt string providing context for table assessment
+   * @param {unknown} inputs - Raw input data to be validated containing table
+   *   information.
+   * @param {Logger} logger - Logger instance for recording table prompt
+   *   operations.
+   * @param {string} [userTemplateName] - Optional name of the user template
+   *   file (defaults to table template).
+   * @param {string} [systemPrompt] - Optional system prompt string providing
+   *   context for table assessment.
    */
   constructor(
     inputs: unknown,

--- a/src/prompt/text.prompt.spec.ts
+++ b/src/prompt/text.prompt.spec.ts
@@ -15,6 +15,11 @@ jest.mock('node:fs/promises', () => ({
 
 const mockedReadFile = jest.mocked(readFile);
 
+/**
+ * Normalise a file path argument to a string.
+ * @param {PathLike | FileHandle} filePath - The file path to normalise.
+ * @returns {string} The normalised file path as a string.
+ */
 function normaliseFilePath(filePath: PathLike | FileHandle): string {
   if (typeof filePath === 'string') return filePath;
   if (Buffer.isBuffer(filePath)) return filePath.toString('utf8');
@@ -23,6 +28,11 @@ function normaliseFilePath(filePath: PathLike | FileHandle): string {
   throw new Error('File handle paths are not supported in this test');
 }
 
+/**
+ * Get the template content for a given file path.
+ * @param {PathLike | FileHandle} filePath - The file path to look up.
+ * @returns {string} The template content string.
+ */
 function getTemplateContent(filePath: PathLike | FileHandle): string {
   const filePathString = normaliseFilePath(filePath);
   if (filePathString.includes('text.system.prompt.md')) return systemTemplate;

--- a/src/prompt/text.prompt.ts
+++ b/src/prompt/text.prompt.ts
@@ -13,11 +13,14 @@ import { Prompt } from './prompt.base';
 export class TextPrompt extends Prompt {
   /**
    * Initialises the TextPrompt instance with text-specific configuration.
-   *
-   * @param inputs - Raw input data to be validated containing text information
-   * @param logger - Logger instance for recording text prompt operations
-   * @param userTemplateName - Optional name of the user template file (defaults to text template)
-   * @param systemPrompt - Optional system prompt string providing context for text assessment
+   * @param {unknown} inputs - Raw input data to be validated containing text
+   *   information.
+   * @param {Logger} logger - Logger instance for recording text prompt
+   *   operations.
+   * @param {string} [userTemplateName] - Optional name of the user template
+   *   file (defaults to text template).
+   * @param {string} [systemPrompt] - Optional system prompt string providing
+   *   context for text assessment.
    */
   constructor(
     inputs: unknown,

--- a/src/status/status.controller.ts
+++ b/src/status/status.controller.ts
@@ -13,8 +13,8 @@ import { StatusService, HealthCheckResponse } from './status.service';
 export class StatusController {
   /**
    * Constructs the StatusController.
-   *
-   * @param statusService - Service providing status and health check functionality
+   * @param {StatusService} statusService - Service providing status and health
+   *   check functionality.
    */
   constructor(private readonly statusService: StatusService) {}
 
@@ -23,8 +23,7 @@ export class StatusController {
    *
    * This endpoint provides a basic connectivity test and confirms the
    * application is responding to requests.
-   *
-   * @returns A simple "Hello World!" message
+   * @returns {string} A simple "Hello World!" message.
    */
   @Get()
   getHello(): string {
@@ -37,8 +36,8 @@ export class StatusController {
    * This endpoint returns detailed information about the application's health,
    * including version, timestamp, and system information. Useful for monitoring
    * and diagnostic purposes.
-   *
-   * @returns Detailed health check response including system information
+   * @returns {HealthCheckResponse} Detailed health check response including
+   *   system information.
    */
   @Get('health')
   getHealth(): HealthCheckResponse {
@@ -50,8 +49,7 @@ export class StatusController {
    *
    * This endpoint is used to test the application's error handling mechanisms
    * and exception filters. It intentionally throws a 400 Bad Request error.
-   *
-   * @throws {HttpException} Always throws a 400 Bad Request error with test message
+   * @throws {HttpException} Always throws a 400 Bad Request error with test message.
    */
   @Get('test-error')
   testError(): void {

--- a/src/status/status.module.ts
+++ b/src/status/status.module.ts
@@ -10,19 +10,18 @@ import { ConfigModule } from '../config/config.module';
  * This module encapsulates all status-related features including health checks,
  * connectivity tests, error testing, and authentication validation. It provides
  * essential monitoring and diagnostic capabilities for the application.
- *
  * @module StatusModule
  *
- * @imports
+ * **imports:**
  * - `ConfigModule`: Required for configuration access
  *
- * @controllers
+ * **controllers:**
  * - `StatusController`: Handles status and health check HTTP endpoints
  *
- * @providers
+ * **providers:**
  * - `StatusService`: Business logic for status and health operations
  *
- * @exports
+ * **exports:**
  * - `StatusService`: Makes the service available to other modules
  */
 @Module({

--- a/src/status/status.service.ts
+++ b/src/status/status.service.ts
@@ -8,21 +8,21 @@ import * as packageJson from '../../package.json';
  * Interface representing system information for health checks.
  */
 interface SystemInfo {
-  /** Operating system platform */
+  /** Operating system platform. */
   platform: string;
-  /** System architecture */
+  /** System architecture. */
   arch: string;
-  /** Operating system release version */
+  /** Operating system release version. */
   release: string;
-  /** System uptime in seconds */
+  /** System uptime in seconds. */
   uptime: number;
-  /** System hostname */
+  /** System hostname. */
   hostname: string;
-  /** Total system memory in bytes */
+  /** Total system memory in bytes. */
   totalMemory: number;
-  /** Free system memory in bytes */
+  /** Free system memory in bytes. */
   freeMemory: number;
-  /** Number of CPU cores */
+  /** Number of CPU cores. */
   cpus: number;
 }
 
@@ -30,13 +30,13 @@ interface SystemInfo {
  * Interface representing the complete health check response.
  */
 export interface HealthCheckResponse {
-  /** Overall application status */
+  /** Overall application status. */
   status: string;
-  /** Application version from package.json */
+  /** Application version from package.json. */
   version: string;
-  /** ISO timestamp of when the health check was performed */
+  /** ISO timestamp of when the health check was performed. */
   timestamp: string;
-  /** Detailed system information */
+  /** Detailed system information. */
   systemInfo: SystemInfo;
 }
 
@@ -54,8 +54,7 @@ export class StatusService {
    *
    * This method provides a basic connectivity test response that confirms
    * the application is running and responding to requests.
-   *
-   * @returns A simple "Hello World!" greeting message
+   * @returns {string} A simple "Hello World!" greeting message.
    */
   getHello(): string {
     return 'Hello World!';
@@ -67,8 +66,8 @@ export class StatusService {
    * This method collects detailed information about the application and system
    * state, including version information, current timestamp, and system metrics
    * such as memory usage, CPU count, and uptime.
-   *
-   * @returns Complete health check response with application and system information
+   * @returns {HealthCheckResponse} Complete health check response with
+   *   application and system information.
    */
   getHealth(): HealthCheckResponse {
     const now = new Date();

--- a/src/testing-main.ts
+++ b/src/testing-main.ts
@@ -8,6 +8,9 @@ import process from 'node:process';
 
 import * as dotenv from 'dotenv';
 
+/**
+ * Start the testing application.
+ */
 export async function startTest(): Promise<void> {
   dotenv.config({ path: '.test.env' });
   const { bootstrap } = await import('./bootstrap');
@@ -30,6 +33,10 @@ if (isRunningDirectly()) {
   })();
 }
 
+/**
+ * Check whether the current module is the main entry point.
+ * @returns {boolean} True if the module is the main entry point.
+ */
 function isRunningDirectly(): boolean {
   return typeof require !== 'undefined' && require.main === module;
 }

--- a/src/v1/assessor/assessor.controller.ts
+++ b/src/v1/assessor/assessor.controller.ts
@@ -16,7 +16,6 @@ import { LlmResponse } from '../../llm/types';
 /**
  * @class AssessorController
  * @description Controller responsible for handling all assessment-related API requests.
- *
  * @remarks
  * This controller is part of the v1 API. It is protected by the `ApiKeyGuard`, ensuring that only
  * authorised clients can access its endpoints. It provides a single endpoint for creating new assessments.
@@ -32,7 +31,6 @@ import { LlmResponse } from '../../llm/types';
  * - The `create` method uses the `ZodValidationPipe` to validate the incoming request body against the `assessorDtoSchema`.
  * - For tasks of type `IMAGE`, it also programmatically uses the `ImageValidationPipe` to perform more complex,
  *   asynchronous validation on the image data itself.
- *
  * @see AppModule - Where the global `ThrottlerGuard` is configured.
  * @see config/throttler.config.ts - Where the `authenticatedThrottler` configuration is defined.
  * @see auth/api-key.guard.ts - The guard that protects this controller.
@@ -58,11 +56,12 @@ export class AssessorController {
    * For IMAGE task types, this method performs additional validation on the
    * image data using the ImageValidationPipe to ensure proper format, size,
    * and MIME type compliance.
-   *
-   * @param assessorDto - Validated data transfer object containing task details
-   * @returns Promise resolving to LLM assessment response with scoring and reasoning
-   * @throws {BadRequestException} If validation fails for any field
-   * @throws {UnauthorizedException} If API key authentication fails
+   * @param {CreateAssessorDto} assessorDto - Validated data transfer object
+   *   containing task details.
+   * @returns {Promise<LlmResponse>} Promise resolving to LLM assessment
+   *   response with scoring and reasoning.
+   * @throws {Error} If validation fails for any field.
+   * @throws {Error} If API key authentication fails.
    */
   @Post()
   async create(

--- a/src/v1/assessor/assessor.controller.ts
+++ b/src/v1/assessor/assessor.controller.ts
@@ -60,8 +60,8 @@ export class AssessorController {
    *   containing task details.
    * @returns {Promise<LlmResponse>} Promise resolving to LLM assessment
    *   response with scoring and reasoning.
-   * @throws {Error} If validation fails for any field.
-   * @throws {Error} If API key authentication fails.
+   * @throws {BadRequestException} If validation fails for any field.
+   * @throws {UnauthorizedException} If API key authentication fails.
    */
   @Post()
   async create(

--- a/src/v1/assessor/assessor.module.ts
+++ b/src/v1/assessor/assessor.module.ts
@@ -11,13 +11,18 @@ import { PromptModule } from '../../prompt/prompt.module';
  * related to the assessor feature in the application. It imports necessary
  * modules, defines controllers, and provides services required for the
  * assessor functionality.
- *
  * @module AssessorModule
- * @imports ConfigModule - Handles application configuration settings.
- * @imports LlmModule - Provides functionality related to large language models.
- * @imports PromptModule - Manages prompt-related operations.
- * @controllers AssessorController - Handles HTTP requests for assessor-related operations.
- * @providers AssessorService - Contains business logic for assessor functionality.
+ *
+ * **imports:**
+ * - `ConfigModule`: Handles application configuration settings.
+ * - `LlmModule`: Provides functionality related to large language models.
+ * - `PromptModule`: Manages prompt-related operations.
+ *
+ * **controllers:**
+ * - `AssessorController`: Handles HTTP requests for assessor-related operations.
+ *
+ * **providers:**
+ * - `AssessorService`: Contains business logic for assessor functionality.
  */
 @Module({
   imports: [ConfigModule, LlmModule, PromptModule],

--- a/src/v1/assessor/assessor.service.spec.ts
+++ b/src/v1/assessor/assessor.service.spec.ts
@@ -69,7 +69,7 @@ describe('AssessorService', () => {
     process.env.API_KEYS = 'test-api-key';
     process.env.MAX_IMAGE_UPLOAD_SIZE_MB = '5';
     process.env.ALLOWED_IMAGE_MIME_TYPES = 'image/png,image/jpeg';
-    process.env.APP_NAME = 'AssessmentBot-Backend';
+    process.env.APP_NAME = 'Assessment Bot LLM Service';
     process.env.APP_VERSION = 'test-version';
     process.env.LOG_LEVEL = 'debug';
   });

--- a/src/v1/assessor/assessor.service.ts
+++ b/src/v1/assessor/assessor.service.ts
@@ -17,9 +17,10 @@ export class AssessorService {
   private readonly logger = new Logger(AssessorService.name);
   /**
    * Constructs an instance of AssessorService.
-   *
-   * @param llmService - The service responsible for interacting with the LLM (Large Language Model).
-   * @param promptFactory - The factory responsible for generating prompts for the LLM.
+   * @param {LLMService} llmService - The service responsible for interacting
+   *   with the LLM.
+   * @param {PromptFactory} promptFactory - The factory responsible for
+   *   generating prompts for the LLM.
    */
   constructor(
     private readonly llmService: LLMService,
@@ -28,11 +29,13 @@ export class AssessorService {
 
   /**
    * Creates an assessment based on the provided data transfer object (DTO).
+   *
    * This method generates a prompt using the `promptFactory`, builds a message,
    * and sends it to the LLM service for processing.
-   *
-   * @param dto - The data transfer object containing the details required to create an assessment.
-   * @returns A promise that resolves to an `LlmResponse` containing the result of the assessment.
+   * @param {CreateAssessorDto} dto - The data transfer object containing the
+   *   details required to create an assessment.
+   * @returns {Promise<LlmResponse>} A promise that resolves to an LlmResponse
+   *   containing the result of the assessment.
    */
   async createAssessment(dto: CreateAssessorDto): Promise<LlmResponse> {
     this.logger.log(`Creating assessment for task type: ${dto.taskType}.`);

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
 # End-to-End (E2E) Testing
 
-This directory contains the end-to-end tests for the AssessmentBot-Backend.
+This directory contains the end-to-end tests for the Assessment Bot LLM Service.
 
 For detailed information on the testing strategy, how to run tests, and how to configure the environment, please see the main [Testing Guide](../../docs/testing/README.md).
 

--- a/test/log-watcher.unit-spec.ts
+++ b/test/log-watcher.unit-spec.ts
@@ -10,10 +10,20 @@ const logger = new Logger('LogWatcherUnit');
 
 jest.setTimeout(5000);
 
+/**
+ * Predicate that matches log entries with msg 'unit-ready'.
+ * @param {LogObject} log - The log object to check.
+ * @returns {boolean} True if the log message is 'unit-ready'.
+ */
 function isUnitReady(log: LogObject): boolean {
   return log.msg === 'unit-ready';
 }
 
+/**
+ * Predicate that matches log entries with msg 'after-malformed'.
+ * @param {LogObject} log - The log object to check.
+ * @returns {boolean} True if the log message is 'after-malformed'.
+ */
 function isAfterMalformed(log: LogObject): boolean {
   return log.msg === 'after-malformed';
 }

--- a/test/logging.e2e-spec.ts
+++ b/test/logging.e2e-spec.ts
@@ -4,7 +4,7 @@
  * This suite verifies that logs are correctly generated, formatted, and contain the expected fields and redactions.
  * It interacts with the running application via HTTP requests and inspects the resulting log file for correctness.
  *
- * @file /workspaces/AssessmentBot-Backend/test/logging.e2e-spec.ts
+ * @file /workspaces/Assessment Bot LLM Service/test/logging.e2e-spec.ts
  *
  * @remarks
  * - The log file is not cleared between tests to preserve log entries for asynchronous operations.

--- a/test/logging.e2e-spec.ts
+++ b/test/logging.e2e-spec.ts
@@ -3,16 +3,12 @@
  *
  * This suite verifies that logs are correctly generated, formatted, and contain the expected fields and redactions.
  * It interacts with the running application via HTTP requests and inspects the resulting log file for correctness.
- *
- * @file /workspaces/Assessment Bot LLM Service/test/logging.e2e-spec.ts
- *
+ * @file /workspaces/Assessment Bot LLM Service/test/logging.e2e-spec.ts.
  * @remarks
  * - The log file is not cleared between tests to preserve log entries for asynchronous operations.
  * - Tests depend on log file contents and may require manual log file management for debugging.
- *
- * @suite Logging (True E2E)
- *
- * @test
+ * **suite:** Logging (True E2E)
+ * **test plan:**
  * 1. Should Propagate Request Context to Injected Loggers
  *    - Ensures that request context (e.g., req.id) is propagated to all relevant log entries.
  * 2. Should Output Valid JSON
@@ -29,7 +25,6 @@
  *    - Placeholder test for log level configuration.
  * 8. Should Handle Large Payloads Without Breaking JSON Output
  *    - Ensures that large request payloads do not break log output formatting.
- *
  * @see startApp, stopApp, getLogObjects, waitForLog
  */
 

--- a/test/logging.e2e-spec.ts
+++ b/test/logging.e2e-spec.ts
@@ -3,7 +3,7 @@
  *
  * This suite verifies that logs are correctly generated, formatted, and contain the expected fields and redactions.
  * It interacts with the running application via HTTP requests and inspects the resulting log file for correctness.
- * @file /workspaces/Assessment Bot LLM Service/test/logging.e2e-spec.ts.
+ * @file /workspaces/AssessmentBot-LLM-Service/test/logging.e2e-spec.ts.
  * @remarks
  * - The log file is not cleared between tests to preserve log entries for asynchronous operations.
  * - Tests depend on log file contents and may require manual log file management for debugging.

--- a/test/prod-tests/docker-image.production-spec.ts
+++ b/test/prod-tests/docker-image.production-spec.ts
@@ -23,6 +23,12 @@ interface AssessorPayload {
   [k: string]: unknown;
 }
 
+/**
+ * Send a POST request with a JSON body to the assessor endpoint.
+ * @param {Record<string, unknown>} payload - The request payload.
+ * @returns {Promise<{ status: number; json: unknown }>} The HTTP status code
+ *   and parsed JSON response.
+ */
 async function postJson(
   payload: Record<string, unknown>,
 ): Promise<{ status: number; json: unknown }> {
@@ -76,6 +82,11 @@ async function postJson(
   });
 }
 
+/**
+ * Evaluate an assessor payload against the running Docker container.
+ * @param {string} _label - A label for the test case (unused).
+ * @param {AssessorPayload} payload - The assessor payload to send.
+ */
 async function evaluate(
   _label: string,
   payload: AssessorPayload,

--- a/test/prod-tests/utils/docker-utilities.ts
+++ b/test/prod-tests/utils/docker-utilities.ts
@@ -7,6 +7,15 @@ export interface CommandResult {
   stderr: string;
 }
 
+/**
+ * Run a command with arguments and return its output.
+ * @param {string} command - The command to run.
+ * @param {string[]} arguments_ - The command arguments.
+ * @param {{ cwd?: string }} [options] - Optional options.
+ * @param {string} [options.cwd] - The working directory for the command.
+ * @returns {Promise<CommandResult>} A promise that resolves with the command
+ *   result.
+ */
 export function runCommand(
   command: string,
   arguments_: string[],
@@ -33,6 +42,11 @@ export function runCommand(
   });
 }
 
+/**
+ * Wait until an HTTP endpoint returns a success status (< 500).
+ * @param {string} url - The URL to poll.
+ * @param {number} timeoutMs - The maximum time to wait in milliseconds.
+ */
 export async function waitForHttp(
   url: string,
   timeoutMs: number,

--- a/test/utils/app-lifecycle.ts
+++ b/test/utils/app-lifecycle.ts
@@ -10,10 +10,18 @@ import { waitForLog } from './log-watcher';
 
 const appLifecycleLogger = new Logger('AppLifecycle');
 
+/**
+ * Listener for child process stderr output.
+ * @param {Buffer} data - The stderr data buffer.
+ */
 function stderrListener(data: Buffer): void {
   appLifecycleLogger.error(`stderr: ${data}`);
 }
 
+/**
+ * Listener for child process stdout output.
+ * @param {Buffer} data - The stdout data buffer.
+ */
 function stdoutListener(data: Buffer): void {
   appLifecycleLogger.debug(`stdout: ${data}`);
 }
@@ -32,12 +40,15 @@ export interface AppInstance {
 }
 
 /**
- * Starts the application in a child process for E2E testing, waits for it to be ready, and returns process info.
- *
- * @param logFilePath - The path to the log file to use for the app process.
- * @param environmentOverrides - A plain JavaScript object to override default environment variables.
- * @returns An object containing the app process, base URL, and API key.
- * @throws If the application fails to start within 30 seconds.
+ * Starts the application in a child process for E2E testing, waits for it to
+ * be ready, and returns process info.
+ * @param {string} logFilePath - The path to the log file to use for the app
+ *   process.
+ * @param {Record<string, string>} [environmentOverrides] - A plain JavaScript
+ *   object to override default environment variables.
+ * @returns {Promise<AppInstance>} An object containing the app process, base
+ *   URL, and API key.
+ * @throws {Error} If the application fails to start within 30 seconds.
  */
 export async function startApp(
   logFilePath: string,
@@ -247,8 +258,8 @@ export async function startApp(
 
 /**
  * Stops the running application process by sending SIGTERM.
- *
- * @param appProcess - The child process running the application.
+ * @param {ChildProcessWithoutNullStreams} appProcess - The child process
+ *   running the application.
  */
 export function stopApp(appProcess: ChildProcessWithoutNullStreams): void {
   if (!(appProcess && !appProcess.killed)) {
@@ -283,9 +294,8 @@ export const API_CALL_DELAY_MS = 2000;
 /**
  * Delays execution for a specified number of milliseconds.
  * Useful for rate limiting test API calls to avoid hitting Gemini API limits.
- *
- * @param ms - The number of milliseconds to delay.
- * @returns A Promise that resolves after the delay.
+ * @param {number} ms - The number of milliseconds to delay.
+ * @returns {Promise<void>} A promise that resolves after the delay.
  */
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/utils/log-watcher.ts
+++ b/test/utils/log-watcher.ts
@@ -62,9 +62,8 @@ export interface LogObject {
 
 /**
  * Reads a log file and parses each line as a LogObject.
- *
- * @param logFilePath - The path to the log file to read.
- * @returns An array of LogObject entries parsed from the file.
+ * @param {string} logFilePath - The path to the log file to read.
+ * @returns {LogObject[]} An array of LogObject entries parsed from the file.
  */
 export function getLogObjects(logFilePath: string): LogObject[] {
   if (!fs.existsSync(logFilePath)) {
@@ -90,12 +89,14 @@ export function getLogObjects(logFilePath: string): LogObject[] {
 }
 
 /**
- * Waits until a log entry matching the given predicate appears in the log file, or times out.
- *
- * @param logFilePath - The path to the log file to monitor.
- * @param predicate - A function that returns true for the desired log entry.
- * @param timeoutMs - The maximum time to wait in milliseconds.
- * @throws If the timeout is reached before a matching log is found.
+ * Waits until a log entry matching the given predicate appears in the log
+ * file, or times out.
+ * @param {string} logFilePath - The path to the log file to monitor.
+ * @param {(log: LogObject) => boolean} predicate - A function that returns true
+ *   for the desired log entry.
+ * @param {number} timeoutMs - The maximum time to wait in milliseconds.
+ * @param {AbortSignal} [signal] - An optional abort signal.
+ * @throws {Error} If the timeout is reached before a matching log is found.
  */
 export async function waitForLog(
   logFilePath: string,


### PR DESCRIPTION
## Summary

This PR is primarily a documentation update with the following changes:

### Documentation
- **Migration planning**: Added SPEC.md, ACTION_PLAN.md, and RESEARCH_FINDINGS.md for Jest → Vitest migration with full ESM support
- **Repo rename**: Updated all documentation and config references from `AssessmentBot-Backend` to `Assessment Bot LLM Service`

### Code changes (supporting documentation standards)
- Added ESLint rules to enforce JSDoc standards
- Re-added JSDoc annotations across the codebase (services, controllers, pipes, filters, etc.)
- Renamed `file-utils.ts` → `file-utilities.ts` and `json-parser.ts` → `json-parser.utility.ts` for consistency
- Removed deprecated barrel exports in config module
- Added `testing-main.ts` bootstrap entry point

These changes are largely mechanical renames and documentation alignment with no functional impact on the API.