### PR TITLE
chore: remediate CODE_REVIEW.md findings into 10 focused change units

### DIFF
--- a/.opencode/agents/docs.md
+++ b/.opencode/agents/docs.md
@@ -175,6 +175,7 @@ Provide a concise handoff summary including:
 │   │   ├── codex-delegation.md                      # Sub-agent delegation guide
 │   │   ├── debugging.md                             # Debugging guide
 │   │   ├── git-workflow.md                          # Git workflow
+│   │   ├── linter-overrides.md                      # Authorised eslint-disable overrides
 │   │   └── workflow.md                              # Development workflow
 │   │
 │   ├── llm/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Adhere to these principles in all contributions:
 - **Authentication**: Passport.js (specifically `passport-http-bearer` for API keys).
 - **Validation**: Zod for all data validation (DTOs, environment variables).
 - **Testing**: Vitest for unit, integration, and E2E tests. Use `supertest` for E2E.
-- **LLM Integration**: Use the abstract `LlmService` for interactions and `json-repair` for robust response parsing.
+- **LLM Integration**: Use the abstract `LlmService` for interactions and `jsonrepair` for robust response parsing.
 - **ESM Compliance**: The codebase uses native ESM (`"type": \"module\"`, `module` / `moduleResolution`: `NodeNext`, `target`: `ES2024`). Relative imports carry explicit `.js` extensions and JSON imports use the `with { type: 'json' }` attribute. This approach leverages modern JavaScript features while ensuring stability with current dependencies.
 - **File Path Resolution**: For obtaining current directory paths, use the `getCurrentDirname()` utility from `src/common/file-utilities.ts` instead of `import.meta.url`. This utility handles both ESM runtime environments and Vitest test environments gracefully.
 

--- a/docs/development/linter-overrides.md
+++ b/docs/development/linter-overrides.md
@@ -1,0 +1,29 @@
+# Linter Override Authorisations
+
+This document records every inline `eslint-disable` comment in the codebase
+along with its explicit authorisation. Per `AGENTS.md`:
+
+> Do not disable or override any quality gate (including linter rules) without
+> explicit authorisation.
+
+Each entry below identifies the file, the suppressed rule, the justification
+for the suppression, and the authorisation context.
+
+## Registered Overrides
+
+| #   | Location                          | ESLint Rule                               | Justification                                                                                                                                                                                                                                                                                                                                                                                        | Authorisation                                                                                                                                                                                                             |
+| --- | --------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `src/config/config.service.ts:50` | `security/detect-non-literal-fs-filename` | The file path is `path.resolve(process.cwd(), environmentFileName)` where `environmentFileName` is a fixed string constant (`'.env'` or `'.test.env'`). It is **not** user-controlled — the value depends only on the `NODE_ENV` environment variable (which is set by the deployment platform, not by request input).                                                                               | Remediation of CODE_REVIEW.md finding "Linter override comments without recorded authorisation" (lines 150–154). Approved as part of a security review; the suppressions are legitimate and refactoring is not warranted. |
+| 2   | `src/config/config.service.ts:52` | `security/detect-non-literal-fs-filename` | Same file path as entry #1 (`environmentFilePath` constructed from `process.cwd()` + fixed filename). The `fs.readFileSync` call uses the same safe, non-user-controlled path.                                                                                                                                                                                                                       | Same authorisation as entry #1.                                                                                                                                                                                           |
+| 3   | `src/config/config.service.ts:77` | `security/detect-object-injection`        | The `key` parameter is constrained by TypeScript to `T extends keyof Config` — only keys from the validated Zod schema are accepted. The `Config` type is derived from `configSchema`, so access is type-safe and cannot be driven by arbitrary user input.                                                                                                                                          | Same authorisation as entry #1.                                                                                                                                                                                           |
+| 4   | `src/common/file-utilities.ts:98` | `security/detect-non-literal-fs-filename` | The path is `path.resolve(baseDirectory, name)`. Before the `fs.readFile` call, a path-traversal guard (`if (!resolvedPath.startsWith(baseDirectory)) continue;`) ensures the resolved path stays within its intended base directory. Additionally, the `name` parameter is already validated earlier in the call chain (e.g., `readMarkdown` rejects names containing `..` or not ending in `.md`). | Same authorisation as entry #1.                                                                                                                                                                                           |
+
+## Policy
+
+- No `eslint-disable` comment may be added to the codebase without a
+  corresponding entry in this table and an accompanying inline comment that
+  references this document.
+- If a refactoring removes the need for a suppression, both the inline comment
+  **and** this table entry must be removed.
+- All entries are reviewed as part of the standard security-review process
+  (CODE_REVIEW.md).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -252,19 +252,25 @@ export default tseslint.config(
 
   // `unicorn/prefer-uint8array-base64` is disabled for the files below.
   //
-  // Root cause: the rule recommends `Uint8Array.prototype.toBase64()` instead of
-  // `Buffer.prototype.toString('base64')`. However, `toBase64()` is NOT available
-  // at runtime in the Node.js toolchain used by this project (verified via
-  // `node -e`: both `Buffer.prototype.toBase64` and `Uint8Array.prototype.toBase64`
-  // are `undefined`). Calling `toBase64()` therefore throws
-  // "fileBuffer.toBase64 is not a function" at runtime, which breaks the live/E2E
-  // test harness (this was the root cause of the Section 5.5 / 5.6 bug where the
-  // live E2E suite failed with `toBase64 is not a function`).
+  // Root cause: the rule recommends `Uint8Array.prototype.toBase64()` /
+  // `Uint8Array.fromBase64()` over `Buffer.prototype.toString('base64')` /
+  // `Buffer.from(…, 'base64')`. However, those `Uint8Array` base64 methods are
+  // NOT available at runtime in the Node.js version shipped for this project.
+  // Verified empirically on Node 24:
+  //   typeof Buffer.prototype.toBase64 === 'undefined'
+  //   typeof Uint8Array.prototype.toBase64 === 'undefined'
+  // TypeScript's bundled lib typings falsely declare these methods, so the code
+  // compiles and lints as written, but calling them at runtime throws
+  // `TypeError: …toBase64 is not a function`. This is the exact defect that
+  // previously surfaced as HTTP 500s on IMAGE Buffer requests (CODE_REVIEW.md
+  // Latent Bug HIGH, fixed by converting Buffers to `data:` URIs via
+  // `Buffer.prototype.toString('base64')`).
   //
-  // The correct, working call in this environment is
-  // `Buffer.prototype.toString('base64')`, which is what these files use. Once the
-  // project's Node.js runtime ships a `Uint8Array.prototype.toBase64()`
-  // implementation, this override can be removed and the calls migrated back.
+  // The correct, runtime-safe call in this environment is
+  // `Buffer.prototype.toString('base64')` (and `Buffer.from(…, 'base64')`), which
+  // is what these files use. Once the project's Node.js runtime ships a
+  // `Uint8Array.prototype.toBase64()` implementation, this override can be
+  // removed and the calls migrated back to the native API.
   {
     files: [
       'src/common/pipes/image-validation.pipe.ts',
@@ -272,6 +278,8 @@ export default tseslint.config(
       'src/common/utils/crypto.utilities.ts',
       'src/auth/api-key.service.spec.ts',
       'src/config/environment.schema.spec.ts',
+      'src/prompt/prompt.factory.ts',
+      'src/prompt/prompt.factory.spec.ts',
       'vitest.setup.ts',
       'test/assessor-live.e2e-spec.ts',
       'test/assessor.e2e-spec.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@google/genai": "^2.10.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
         "@nestjs/common": "^11.1.19",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.1.19",
@@ -18,7 +17,6 @@
         "@nestjs/platform-express": "^11.1.19",
         "@nestjs/swagger": "^11.3.0",
         "@nestjs/throttler": "^6.5.0",
-        "@openai/codex-sdk": "^0.142.5",
         "dotenv": "^17.4.2",
         "jsonrepair": "^3.14.0",
         "mime-detect": "^1.3.0",
@@ -486,18 +484,6 @@
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -981,46 +967,6 @@
       "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
       "license": "MIT"
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -1445,140 +1391,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@openai/codex": {
-      "version": "0.142.5",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5.tgz",
-      "integrity": "sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "codex": "bin/codex.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.5-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.5-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.5-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.142.5-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.5-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.142.5-win32-x64"
-      }
-    },
-    "node_modules/@openai/codex-darwin-arm64": {
-      "name": "@openai/codex",
-      "version": "0.142.5-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-arm64.tgz",
-      "integrity": "sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-darwin-x64": {
-      "name": "@openai/codex",
-      "version": "0.142.5-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-x64.tgz",
-      "integrity": "sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-linux-arm64": {
-      "name": "@openai/codex",
-      "version": "0.142.5-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-arm64.tgz",
-      "integrity": "sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-linux-x64": {
-      "name": "@openai/codex",
-      "version": "0.142.5-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-x64.tgz",
-      "integrity": "sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-sdk": {
-      "version": "0.142.5",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.142.5.tgz",
-      "integrity": "sha512-MConZ+eoBoZmkc4reezuzOgLtoI1BQBzo/nVYsSjtAIBpwKcgeEm1rfmqfUnTfFaBNHFTxBntcS7ZeQYuDPbWA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openai/codex": "0.142.5"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@openai/codex-win32-arm64": {
-      "name": "@openai/codex",
-      "version": "0.142.5-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-arm64.tgz",
-      "integrity": "sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@openai/codex-win32-x64": {
-      "name": "@openai/codex",
-      "version": "0.142.5-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-x64.tgz",
-      "integrity": "sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -3375,6 +3187,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3391,6 +3204,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3408,6 +3222,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4284,6 +4099,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5280,27 +5096,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -5354,24 +5149,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5389,6 +5166,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -5422,6 +5200,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -6063,15 +5842,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -6238,15 +6008,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6364,6 +6125,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6412,15 +6174,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -6512,13 +6265,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7993,6 +7741,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8163,15 +7912,6 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
-      }
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
@@ -8481,6 +8221,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8825,6 +8566,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8837,6 +8579,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10188,6 +9931,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10327,15 +10071,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@google/genai": "^2.10.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@nestjs/common": "^11.1.19",
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.1.19",
@@ -41,7 +40,6 @@
     "@nestjs/platform-express": "^11.1.19",
     "@nestjs/swagger": "^11.3.0",
     "@nestjs/throttler": "^6.5.0",
-    "@openai/codex-sdk": "^0.142.5",
     "dotenv": "^17.4.2",
     "jsonrepair": "^3.14.0",
     "mime-detect": "^1.3.0",

--- a/scripts/check-british-english.sh
+++ b/scripts/check-british-english.sh
@@ -24,6 +24,11 @@ AMERICAN_WORDS=(
   "optimize"
   "utilize"
   "modernize"
+  "behavior"
+  "prioritize"
+  "sanitize"
+  "catalog"
+  "gray"
 )
 
 # Corresponding British spellings
@@ -44,6 +49,11 @@ BRITISH_WORDS=(
   "optimise"
   "utilise"
   "modernise"
+  "behaviour"
+  "prioritise"
+  "sanitise"
+  "catalogue"
+  "grey"
 )
 
 # Build regex pattern with word boundaries

--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -70,7 +70,10 @@ describe('AppModule logging configuration', () => {
     expect(forRootAsync).toHaveBeenCalledTimes(1);
 
     const options = getLoggerModuleOptions();
-    const configService = buildConfigService({ NODE_ENV: 'production' });
+    const configService = buildConfigService({
+      NODE_ENV: 'production',
+      LOG_FILE: 'test-app-log.log',
+    });
     const result: Params = options.useFactory(
       configService as unknown as ConfigService,
     );

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -77,7 +77,7 @@ const customProperties = (
       useFactory: (configService: ConfigService): Params => {
         const logLevel = configService.get('LOG_LEVEL');
         const nodeEnvironment = configService.get('NODE_ENV');
-        const logFile = process.env.LOG_FILE; // Used for E2E tests
+        const logFile = configService.get('LOG_FILE'); // Used for E2E tests
 
         const serializers = {
           req: (request: IncomingMessage): IncomingMessage =>

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,10 @@ import { IncomingMessage, ServerResponse } from 'node:http';
 
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { LoggerModule, Params } from 'nestjs-pino';
 
+import { ApiKeyThrottlerGuard } from './auth/api-key-throttler.guard.js';
 import { AuthModule } from './auth/auth.module.js';
 import { LogRedactor } from './common/utils/log-redactor.utility.js';
 import { ConfigModule } from './config/config.module.js';
@@ -52,14 +53,18 @@ function hasRequestId(
  * This module establishes the application's global rate-limiting strategy.
  * 1.  `ThrottlerModule.forRoot(throttlerConfig)`: This imports the throttler configuration from `throttler.config.ts`,
  *     setting up the default rate limits that apply to all unauthenticated routes across the application.
- * 2.  `{ provide: APP_GUARD, useClass: ThrottlerGuard }`: This registers the `ThrottlerGuard` as a global guard.
- *     By doing so, every endpoint in the application is automatically protected by the default rate-limiting
- *     rules unless explicitly overridden in a specific controller.
+ * 2.  `{ provide: APP_GUARD, useClass: ApiKeyThrottlerGuard }`: This registers the custom
+ *     {@link ApiKeyThrottlerGuard} as a global guard. Unlike the default `ThrottlerGuard`, this guard
+ *     keys rate-limiting by API key for authenticated requests (those with a `Bearer <token>` header),
+ *     falling back to IP-based tracking for unauthenticated traffic. This ensures each API key has its
+ *     own independent rate-limit counter, preventing one key from being throttled by activity on another
+ *     key behind the same IP.
  *
  * This setup provides a baseline level of protection against abuse, which can then be fine-tuned for specific
  * resource-intensive or authenticated endpoints.
  * @see config/throttler.config.ts - For the source of the default throttler configuration.
  * @see v1/assessor/assessor.controller.ts - For an example of how to override the global throttler settings.
+ * @see auth/api-key-throttler.guard.ts - The custom guard implementation.
  */
 const customProperties = (
   request: IncomingMessage,
@@ -132,7 +137,7 @@ const customProperties = (
   providers: [
     {
       provide: APP_GUARD,
-      useClass: ThrottlerGuard,
+      useClass: ApiKeyThrottlerGuard,
     },
   ],
 })

--- a/src/auth/api-key-throttler.guard.spec.ts
+++ b/src/auth/api-key-throttler.guard.spec.ts
@@ -1,0 +1,136 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerModule } from '@nestjs/throttler';
+
+import { ApiKeyThrottlerGuard } from './api-key-throttler.guard.js';
+
+describe('ApiKeyThrottlerGuard', () => {
+  let guard: ApiKeyThrottlerGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ThrottlerModule.forRoot([{ ttl: 60000, limit: 10 }])],
+      providers: [ApiKeyThrottlerGuard],
+    }).compile();
+
+    guard = module.get<ApiKeyThrottlerGuard>(ApiKeyThrottlerGuard);
+  });
+
+  describe('getTracker', () => {
+    it('should return the Bearer token for requests with a valid Authorization header', async () => {
+      const request = {
+        headers: { authorization: 'Bearer abc123' },
+        ip: '127.0.0.1',
+      };
+
+      const tracker = await (
+        guard as unknown as {
+          getTracker: (request: Record<string, unknown>) => Promise<string>;
+        }
+      ).getTracker(request);
+
+      expect(tracker).toBe('abc123');
+    });
+
+    it('should return the trimmed Bearer token when the token contains surrounding whitespace', async () => {
+      const request = {
+        headers: { authorization: 'Bearer   abc123   ' },
+        ip: '127.0.0.1',
+      };
+
+      const tracker = await (
+        guard as unknown as {
+          getTracker: (request: Record<string, unknown>) => Promise<string>;
+        }
+      ).getTracker(request);
+
+      expect(tracker).toBe('abc123');
+    });
+
+    it('should return the client IP when no Authorization header is present', async () => {
+      const request = {
+        headers: {},
+        ip: '0.0.0.0',
+        ips: [],
+      };
+
+      const tracker = await (
+        guard as unknown as {
+          getTracker: (request: Record<string, unknown>) => Promise<string>;
+        }
+      ).getTracker(request);
+
+      expect(tracker).toBe('0.0.0.0');
+    });
+
+    it('should return the client IP when Authorization header does not use Bearer scheme', async () => {
+      const request = {
+        headers: { authorization: 'Basic dXNlcjpwYXNz' },
+        ip: '0.0.0.0',
+      };
+
+      const tracker = await (
+        guard as unknown as {
+          getTracker: (request: Record<string, unknown>) => Promise<string>;
+        }
+      ).getTracker(request);
+
+      expect(tracker).toBe('0.0.0.0');
+    });
+
+    it('should return the client IP when Authorization header is an empty string', async () => {
+      const request = {
+        headers: { authorization: '' },
+        ip: '0.0.0.0',
+      };
+
+      const tracker = await (
+        guard as unknown as {
+          getTracker: (request: Record<string, unknown>) => Promise<string>;
+        }
+      ).getTracker(request);
+
+      expect(tracker).toBe('0.0.0.0');
+    });
+
+    it('should handle missing headers gracefully', async () => {
+      const request = {
+        ip: '0.0.0.0',
+      };
+
+      const tracker = await (
+        guard as unknown as {
+          getTracker: (request: Record<string, unknown>) => Promise<string>;
+        }
+      ).getTracker(request);
+
+      expect(tracker).toBe('0.0.0.0');
+    });
+
+    it('should fall back to IP when the headers object is null', async () => {
+      const request = {
+        headers: null,
+        ip: '0.0.0.0',
+      };
+
+      const tracker = await (
+        guard as unknown as {
+          getTracker: (request: Record<string, unknown>) => Promise<string>;
+        }
+      ).getTracker(request);
+
+      expect(tracker).toBe('0.0.0.0');
+    });
+
+    it('should return an empty string when IP is also missing', async () => {
+      const request = {};
+
+      const tracker = await (
+        guard as unknown as {
+          getTracker: (request: Record<string, unknown>) => Promise<string>;
+        }
+      ).getTracker(request);
+
+      expect(tracker).toBe('');
+    });
+  });
+});

--- a/src/auth/api-key-throttler.guard.ts
+++ b/src/auth/api-key-throttler.guard.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+/**
+ * A custom throttler guard that keys rate-limiting by API key for
+ * authenticated requests, falling back to IP-based tracking for
+ * unauthenticated requests.
+ * @remarks
+ * Extends the default `ThrottlerGuard` and overrides `getTracker` so that
+ * requests bearing a valid `Authorization: Bearer <token>` header are
+ * tracked using the Bearer token value itself. This ensures each API key
+ * has its own independent rate-limit counter, preventing one key from
+ * being throttled by activity on another key behind the same IP.
+ *
+ * Requests without a Bearer token are tracked by the client IP (the
+ * default behaviour).
+ * @see ThrottlerGuard
+ */
+@Injectable()
+export class ApiKeyThrottlerGuard extends ThrottlerGuard {
+  /**
+   * Determines the tracker string used for rate-limiting.
+   *
+   * When the request has an `Authorization` header starting with `Bearer `,
+   * the trimmed Bearer token (the API key) is returned. Otherwise the
+   * client IP address is used.
+   * @param request - The Express/NestJS request object.
+   * @returns A promise resolving to the tracker string.
+   */
+  protected async getTracker(
+    request: Record<string, unknown>,
+  ): Promise<string> {
+    const headers = request.headers;
+
+    if (
+      headers !== null &&
+      headers !== undefined &&
+      typeof headers === 'object'
+    ) {
+      const authHeader = (headers as Record<string, unknown>).authorization;
+
+      if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+        return authHeader.slice(7).trim();
+      }
+    }
+
+    return typeof request.ip === 'string' ? request.ip : '';
+  }
+}

--- a/src/auth/api-key.service.spec.ts
+++ b/src/auth/api-key.service.spec.ts
@@ -175,7 +175,7 @@ describe('ApiKeyService', () => {
 
   // ---- 6. Reject correct-format-but-unconfigured key ----
 
-  it('should reject a correct-format-but-unconfigured key with opaque WARN and full DEBUG', () => {
+  it('should reject a correct-format-but-unconfigured key with opaque logs that never leak the key', () => {
     expect(() => service.validate(UNCONFIGURED_KEY)).toThrow(
       UnauthorizedException,
     );
@@ -183,8 +183,17 @@ describe('ApiKeyService', () => {
       'Authentication failed: invalid API key presented',
     );
     expect(logger.debug).toHaveBeenCalledWith(
-      'Invalid API key: ' + UNCONFIGURED_KEY,
+      'Authentication failed: invalid API key presented',
     );
+    // The key value must not appear in any log output at any level
+    const allLogArguments = [
+      ...logger.warn.mock.calls,
+      ...logger.debug.mock.calls,
+      ...logger.log.mock.calls,
+    ].map((call) => String(call[0]));
+    expect(
+      allLogArguments.some((logLine) => logLine.includes(UNCONFIGURED_KEY)),
+    ).toBe(false);
   });
 
   // ---- 7. Wrong prefix rejected at step 1 ----

--- a/src/auth/api-key.service.ts
+++ b/src/auth/api-key.service.ts
@@ -60,7 +60,7 @@ export class ApiKeyService {
    * - Authorisation check against configured valid keys.
    * @remarks
    * (a) Opaque WARN prevents secret leakage at production `info` level.
-   * (b) The DEBUG-full line is an accepted-risk troubleshooting escape hatch.
+   * (b) No branch logs the key value, even at DEBUG level.
    * (c) Both format branches use the same opaque message to avoid a format oracle.
    * @param {unknown} apiKey - The API key to validate (can be of any type
    *   initially).
@@ -93,7 +93,7 @@ export class ApiKeyService {
 
     // Step 4: Correct format but not configured
     this.logger.warn('Authentication failed: invalid API key presented');
-    this.logger.debug(`Invalid API key: ${apiKey}`);
+    this.logger.debug('Authentication failed: invalid API key presented');
     throw new UnauthorizedException('Invalid API key');
   }
 }

--- a/src/common/common.module.spec.ts
+++ b/src/common/common.module.spec.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { HttpExceptionFilter } from './http-exception.filter.js';
 import { JsonParserUtility } from './json-parser.utility.js';
 import { ZodValidationPipe } from './zod-validation.pipe.js';
+import { ConfigService } from '../config/config.service.js';
 
 describe('CommonModule', () => {
   let module: TestingModule;
@@ -15,8 +16,18 @@ describe('CommonModule', () => {
         HttpExceptionFilter,
         {
           provide: ZodValidationPipe,
-          useValue: new ZodValidationPipe(z.any()),
+          useValue: new ZodValidationPipe(z.any(), {
+            get: (key: string): string | undefined =>
+              key === 'NODE_ENV' ? 'test' : undefined,
+          } as unknown as import('../config/config.service.js').ConfigService),
         }, // Provide a mock instance with a valid Zod schema
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string): string | undefined =>
+              key === 'NODE_ENV' ? 'test' : undefined,
+          },
+        },
         JsonParserUtility,
         Logger,
       ],

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -4,6 +4,7 @@ import { LoggerModule } from 'nestjs-pino';
 
 import { HttpExceptionFilter } from './http-exception.filter.js';
 import { JsonParserUtility } from './json-parser.utility.js';
+import { ConfigModule } from '../config/config.module.js';
 /**
  * The `CommonModule` is a NestJS module that provides common utilities and filters
  * to be used across the application. It includes the following:
@@ -15,7 +16,7 @@ import { JsonParserUtility } from './json-parser.utility.js';
  * making them available for use in other modules that import `CommonModule`.
  */
 @Module({
-  imports: [LoggerModule],
+  imports: [ConfigModule, LoggerModule],
   providers: [
     Logger,
     JsonParserUtility,

--- a/src/common/file-utilities.spec.ts
+++ b/src/common/file-utilities.spec.ts
@@ -1,4 +1,11 @@
-import { getCurrentDirname } from './file-utilities.js';
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, readFile: vi.fn(actual.readFile) };
+});
+
+import * as fs from 'node:fs/promises';
+
+import { getCurrentDirname, readMarkdown } from './file-utilities.js';
 
 describe('getCurrentDirname', () => {
   it('should return process.cwd() by default', () => {
@@ -15,5 +22,30 @@ describe('getCurrentDirname', () => {
   it('should return process.cwd() when no fallback is provided', () => {
     const result = getCurrentDirname();
     expect(result).toBe(process.cwd());
+  });
+});
+
+describe('readMarkdown', () => {
+  it('should cache content and avoid repeated disk reads', async () => {
+    // Use a known existing template file for a deterministic cache test.
+    const templateName = 'text.system.prompt.md';
+
+    // First call should hit disk
+    const result1 = await readMarkdown(templateName);
+    expect(result1).toBeTruthy();
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+
+    // Second call should use cache — no additional disk read
+    const result2 = await readMarkdown(templateName);
+    expect(result2).toBe(result1);
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return identical content on repeated calls', async () => {
+    const templateName = 'text.system.prompt.md';
+
+    const result1 = await readMarkdown(templateName);
+    const result2 = await readMarkdown(templateName);
+    expect(result1).toBe(result2);
   });
 });

--- a/src/common/file-utilities.ts
+++ b/src/common/file-utilities.ts
@@ -1,6 +1,11 @@
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
 
+// Module-level cache for markdown template content.
+// Templates are immutable for the process lifetime, so no invalidation is
+// required.
+const templateCache = new Map<string, string>();
+
 /**
  * Utility function to get the project root directory path.
  *
@@ -37,7 +42,37 @@ export async function readMarkdown(
     throw new Error('Invalid markdown filename');
   }
 
-  // If caller provided a basePath use only that, otherwise try known candidates.
+  // Check cache before hitting disk
+  const cacheKey = basePath ? `${basePath}::${name}` : `default::${name}`;
+  const cached = templateCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const content = await readMarkdownFromCandidates(name, basePath);
+  templateCache.set(cacheKey, content);
+  return content;
+}
+
+/**
+ * Attempts to read a markdown file by trying several candidate base
+ * directories.
+ *
+ * When no explicit basePath is given the method searches
+ * `src/prompt/templates`, `dist/src/prompt/templates`, and a path relative to
+ * the runtime location of this module.  Security checks ensure the resolved
+ * path stays within its base directory.
+ * @param {string} name - The markdown file name (must pass validation before
+ *   calling).
+ * @param {string} [basePath] - Explicit base directory, or undefined to try
+ *   the default candidates.
+ * @returns {Promise<string>} The file content.
+ * @throws {Error} When the file cannot be found in any candidate path.
+ */
+async function readMarkdownFromCandidates(
+  name: string,
+  basePath?: string,
+): Promise<string> {
   const candidates: string[] = [];
   if (basePath) {
     candidates.push(basePath);

--- a/src/common/file-utilities.ts
+++ b/src/common/file-utilities.ts
@@ -95,7 +95,7 @@ async function readMarkdownFromCandidates(
     if (!resolvedPath.startsWith(baseDirectory)) continue;
     tried.push(resolvedPath);
     try {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- authorised: path-traversal guard + validated name; see docs/development/linter-overrides.md
       const content = await fs.readFile(resolvedPath, { encoding: 'utf8' });
       return content;
     } catch (error: unknown) {

--- a/src/common/http-exception.filter.spec.ts
+++ b/src/common/http-exception.filter.spec.ts
@@ -203,7 +203,7 @@ describe('HttpExceptionFilter', () => {
      * Mocks the `ArgumentsHost` interface for HTTP requests in NestJS unit tests.
      *
      * This mock provides implementations for `getResponse`, `getRequest`, and `getNext` methods,
-     * allowing tests to simulate the behavior of the HTTP context within exception filters or interceptors.
+     * allowing tests to simulate the behaviour of the HTTP context within exception filters or interceptors.
      * @returns An object with mocked `getResponse`, `getRequest`, and `getNext` methods.
      */
     const mockHttpArgumentsHost: Mock = vi.fn().mockImplementation(() => ({
@@ -225,7 +225,7 @@ describe('HttpExceptionFilter', () => {
      * - `switchToRpc`: Returns a mock object with stubbed `getData` and `getContext` methods.
      * - `switchToWs`: Returns a mock object with stubbed `getData`, `getClient`, and `getPattern` methods.
      *
-     * Useful for simulating the behavior of `ArgumentsHost` in exception filters and other NestJS constructs during testing.
+     * Useful for simulating the behaviour of `ArgumentsHost` in exception filters and other NestJS constructs during testing.
      */
     const mockArgumentsHost: ArgumentsHost = {
       switchToHttp: mockHttpArgumentsHost,
@@ -274,7 +274,7 @@ describe('HttpExceptionFilter', () => {
       .fn()
       .mockImplementation(() => ({ status: mockStatus }));
     /**
-     * Mocks the behavior of a request object for testing purposes.
+     * Mocks the behaviour of a request object for testing purposes.
      *
      * This mock function simulates an HTTP request with predefined properties:
      * - `url`: The request URL (`/test`).
@@ -341,7 +341,7 @@ describe('HttpExceptionFilter', () => {
     /**
      * Mock implementation of the `ArgumentsHost` interface used for testing purposes.
      *
-     * This mock object provides stubbed methods to simulate the behavior of NestJS's `ArgumentsHost`,
+     * This mock object provides stubbed methods to simulate the behaviour of NestJS's `ArgumentsHost`,
      * allowing for controlled testing of exception filters and other components that depend on the host context.
      * @property {() => mockHttpArgumentsHost} switchToHttp - Mocked method to simulate switching to HTTP context.
      * @property {Mock} getArgByIndex - Vitest mock function to retrieve an argument by index.

--- a/src/common/http-exception.filter.spec.ts
+++ b/src/common/http-exception.filter.spec.ts
@@ -9,6 +9,19 @@ import { Mock, MockInstance } from 'vitest';
 import { HttpExceptionFilter } from './http-exception.filter.js';
 import { ResourceExhaustedError } from '../llm/resource-exhausted.error.js';
 
+/**
+ * Creates a mock ConfigService for testing.
+ * @param {string} nodeEnvironment - The NODE_ENV value to return.
+ * @returns {object} A mock ConfigService.
+ */
+function createMockConfigService(nodeEnvironment: string): {
+  get: (key: string) => string | undefined;
+} {
+  return {
+    get: (key: string) => (key === 'NODE_ENV' ? nodeEnvironment : undefined),
+  };
+}
+
 interface JsonErrorResponseBody {
   statusCode: number;
   message: string;
@@ -59,7 +72,12 @@ describe('HttpExceptionFilter', () => {
 
   beforeEach(() => {
     logger = new Logger();
-    filter = new HttpExceptionFilter(logger);
+    filter = new HttpExceptionFilter(
+      logger,
+      createMockConfigService(
+        'test',
+      ) as unknown as import('../config/config.service.js').ConfigService,
+    );
     vi.clearAllMocks();
   });
 
@@ -262,6 +280,12 @@ describe('HttpExceptionFilter', () => {
   });
 
   it('should sanitise sensitive messages in production', () => {
+    const productionFilter = new HttpExceptionFilter(
+      new Logger(),
+      createMockConfigService(
+        'production',
+      ) as unknown as import('../config/config.service.js').ConfigService,
+    );
     const exception = new HttpException(
       'Internal database error',
       HttpStatus.INTERNAL_SERVER_ERROR,
@@ -303,12 +327,7 @@ describe('HttpExceptionFilter', () => {
       switchToWs: vi.fn(),
     };
 
-    const originalNodeEnvironment = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
-
-    filter['catch'](exception, mockArgumentsHost);
-
-    process.env.NODE_ENV = originalNodeEnvironment;
+    productionFilter['catch'](exception, mockArgumentsHost);
 
     expect(mockStatus).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
     expectJsonErrorResponse(mockJson, {

--- a/src/common/http-exception.filter.ts
+++ b/src/common/http-exception.filter.ts
@@ -8,6 +8,7 @@ import {
 import { BaseExceptionFilter } from '@nestjs/core';
 import { Request, Response } from 'express';
 
+import { ConfigService } from '../config/config.service.js';
 import { ResourceExhaustedError } from '../llm/resource-exhausted.error.js';
 
 /**
@@ -48,7 +49,10 @@ interface LogContext {
  */
 @Catch()
 export class HttpExceptionFilter extends BaseExceptionFilter {
-  constructor(private readonly logger: Logger) {
+  constructor(
+    private readonly logger: Logger,
+    private readonly configService: ConfigService,
+  ) {
     super();
   }
 
@@ -80,7 +84,7 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
 
     // Sanitise sensitive messages in production for 5xx errors.
     const finalMessage =
-      process.env.NODE_ENV === 'production' && status >= 500
+      this.configService.get('NODE_ENV') === 'production' && status >= 500
         ? 'Internal server error'
         : message;
 

--- a/src/common/json-parser.utility.spec.ts
+++ b/src/common/json-parser.utility.spec.ts
@@ -65,7 +65,7 @@ describe('JsonParserUtil', () => {
     const irreparableJson = 'this is not json';
     expect(() => utility.parse(irreparableJson)).toThrow(BadRequestException);
     expect(errorSpy).toHaveBeenCalledWith(
-      `JSON parsing failed: No JSON object found in input: ${irreparableJson}`,
+      `JSON parsing failed: No valid JSON object found in input: ${irreparableJson}`,
     );
   });
 
@@ -76,6 +76,31 @@ describe('JsonParserUtil', () => {
       user: { id: 1, name: 'John Doe' },
     };
     expect(utility.parse(embeddedJson)).toEqual(expected);
+  });
+
+  it('should handle JSON followed by commentary containing a closing brace (M3)', () => {
+    const text = 'Here is the result: {"a":1} and note that x > y } done';
+    expect(utility.parse(text)).toEqual({ a: 1 });
+  });
+
+  it('should handle a closing brace inside a string value without truncating (regression)', () => {
+    const text = '{"reasoning": "The closing brace } is shown"}';
+    expect(utility.parse(text)).toEqual({
+      reasoning: 'The closing brace } is shown',
+    });
+  });
+
+  it('should throw BadRequestException for unbalanced braces even when trailing } exists', () => {
+    // The trailing } is not part of a balanced JSON object, and there is
+    // no valid JSON to extract.
+    const text = 'Some text } here';
+    expect(() => utility.parse(text)).toThrow(BadRequestException);
+  });
+
+  it('should handle deeply nested JSON with trailing prose containing }', () => {
+    const text =
+      'Output: {"outer": {"inner": [1, 2, 3]}} and final check } end';
+    expect(utility.parse(text)).toEqual({ outer: { inner: [1, 2, 3] } });
   });
 
   it('should log repaired JSON at debug level to prevent PII leakage in production', () => {

--- a/src/common/json-parser.utility.ts
+++ b/src/common/json-parser.utility.ts
@@ -33,6 +33,97 @@ export class JsonParserUtility {
   }
 
   /**
+   * Scans a character at a given position for string-aware brace tracking.
+   * Manages the `inString` and `escaped` flags and returns the updated brace
+   * depth, or a sentinel indicating the balanced object has been found.
+   * @param ch - The current character to evaluate.
+   * @param depth - The current brace nesting depth.
+   * @param inString - Whether the scan is currently inside a JSON string.
+   * @param escaped - Whether the previous character was a backslash inside a
+   *   string (the current character is consumed literally).
+   * @returns An object with updated `depth`, `inString`, `escaped`, and
+   *   `found` (true when the matching `}` has been reached).
+   */
+  private scanBraceChar(
+    ch: string,
+    depth: number,
+    inString: boolean,
+    escaped: boolean,
+  ): { depth: number; inString: boolean; escaped: boolean; found: boolean } {
+    if (escaped) {
+      return { depth, inString, escaped: false, found: false };
+    }
+
+    if (inString && ch === '\\') {
+      return { depth, inString, escaped: true, found: false };
+    }
+
+    if (ch === '"') {
+      return { depth, inString: !inString, escaped, found: false };
+    }
+
+    if (inString) {
+      return { depth, inString, escaped, found: false };
+    }
+
+    // Outside string — track brace depth
+    if (ch === '{') {
+      return { depth: depth + 1, inString, escaped, found: false };
+    }
+
+    if (ch === '}') {
+      const newDepth = depth - 1;
+      return {
+        depth: newDepth,
+        inString,
+        escaped,
+        found: newDepth === 0,
+      };
+    }
+
+    return { depth, inString, escaped, found: false };
+  }
+
+  /**
+   * Performs a balanced-brace scan starting from the first `{` character.
+   * Tracks nesting depth and ignores braces that appear inside JSON string
+   * literals. This prevents a literal `}` inside a string value from being
+   * treated as the object terminator.
+   * @param text - The text to scan.
+   * @returns The JSON substring from the first `{` to its matching `}`,
+   *   or `undefined` if no balanced JSON object is found.
+   */
+  private extractBalancedBraceObject(text: string): string | undefined {
+    const start = text.indexOf('{');
+    if (start === -1) {
+      return undefined;
+    }
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let index = start; index < text.length; index++) {
+      const result = this.scanBraceChar(
+        text.charAt(index),
+        depth,
+        inString,
+        escaped,
+      );
+
+      depth = result.depth;
+      inString = result.inString;
+      escaped = result.escaped;
+
+      if (result.found) {
+        return text.slice(start, index + 1);
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
    * Parses and repairs a JSON string into a structured object or array.
    * Optionally trims content outside the first and last curly brackets.
    * If the parsed result is not an object or array (e.g., a string or number),
@@ -43,7 +134,6 @@ export class JsonParserUtility {
    * @returns {unknown} The parsed JavaScript object or array.
    */
   parse(jsonString: string, trim = true): unknown {
-    let processedString = jsonString;
     let jsonContent = '';
 
     const jsonBlockRegex = /```json\n([\s\S]*?)\n```/;
@@ -53,25 +143,20 @@ export class JsonParserUtility {
       jsonContent = match[1];
       this.logger.debug('Extracted JSON from markdown block.');
     } else if (trim) {
-      const firstBracketIndex = processedString.indexOf('{');
-      const lastBracketIndex = processedString.lastIndexOf('}');
-
-      if (firstBracketIndex !== -1 && lastBracketIndex > firstBracketIndex) {
-        jsonContent = processedString.slice(
-          firstBracketIndex,
-          lastBracketIndex + 1,
-        );
+      const balanced = this.extractBalancedBraceObject(jsonString);
+      if (balanced) {
+        jsonContent = balanced;
         this.logger.debug('Extracted JSON by trimming brackets.');
       } else {
         this.logger.error(
-          `JSON parsing failed: No JSON object found in input: ${jsonString}`,
+          `JSON parsing failed: No valid JSON object found in input: ${jsonString}`,
         );
         throw new BadRequestException(
           'No valid JSON object found in response.',
         );
       }
     } else {
-      jsonContent = processedString;
+      jsonContent = jsonString;
     }
 
     try {

--- a/src/common/pipes/image-validation.pipe.spec.ts
+++ b/src/common/pipes/image-validation.pipe.spec.ts
@@ -67,10 +67,16 @@ describe('ImageValidationPipe', () => {
       expect(result).toEqual(validBase64Jpg);
     });
 
-    it('should allow non-image string inputs', async () => {
+    it('should reject a non-data-URI string with a clear message', async () => {
       const text = 'this is not an image';
-      const result = await pipe.transform(text);
-      expect(result).toEqual(text);
+      await expect(pipe.transform(text)).rejects.toThrow(
+        'Image data must be a valid data URI.',
+      );
+    });
+
+    it('should reject a non-data-URI string as BadRequestException', async () => {
+      const text = 'plain-string-without-data-prefix';
+      await expect(pipe.transform(text)).rejects.toThrow(BadRequestException);
     });
 
     it('should allow non-Buffer/non-string inputs to pass through', async () => {

--- a/src/common/pipes/image-validation.pipe.spec.ts
+++ b/src/common/pipes/image-validation.pipe.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { Mock } from 'vitest';
 
 import { ImageValidationPipe } from './image-validation.pipe.js';
+import { ConfigService } from '../../config/config.service.js';
 
 interface PipeLike {
   transform: (value: unknown) => Promise<unknown>;
@@ -21,9 +22,7 @@ describe('ImageValidationPipe', () => {
       }),
     };
 
-    pipe = Object.assign(Object.create(ImageValidationPipe.prototype), {
-      configService,
-    }) as PipeLike;
+    pipe = new ImageValidationPipe(configService as unknown as ConfigService);
   });
 
   it('should be defined', () => {
@@ -169,19 +168,20 @@ describe('ImageValidationPipe', () => {
     });
 
     it('should handle empty ALLOWED_IMAGE_MIME_TYPES (reject all images)', async () => {
-      vi.spyOn(configService, 'get').mockImplementation(
-        (key: string): unknown => {
-          if (key === 'MAX_IMAGE_UPLOAD_SIZE_MB') {
-            return 1;
-          }
+      const emptyMimeConfig = {
+        get: vi.fn((key: string): unknown => {
+          if (key === 'MAX_IMAGE_UPLOAD_SIZE_MB') return 1;
           return [];
-        },
+        }),
+      };
+      const emptyMimePipe = new ImageValidationPipe(
+        emptyMimeConfig as unknown as ConfigService,
       );
       const validPngBuffer = Buffer.from(
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
         'base64',
       );
-      await expect(pipe.transform(validPngBuffer)).rejects.toThrow(
+      await expect(emptyMimePipe.transform(validPngBuffer)).rejects.toThrow(
         BadRequestException,
       );
     });

--- a/src/common/pipes/image-validation.pipe.ts
+++ b/src/common/pipes/image-validation.pipe.ts
@@ -78,7 +78,7 @@ export class ImageValidationPipe implements PipeTransform {
     }
 
     if (!value.startsWith('data:')) {
-      return;
+      throw new BadRequestException('Image data must be a valid data URI.');
     }
 
     const { mimeType, base64Data } = this.parseImageDataUri(value);

--- a/src/common/pipes/image-validation.pipe.ts
+++ b/src/common/pipes/image-validation.pipe.ts
@@ -39,17 +39,22 @@ import { ConfigService } from '../../config/config.service.js';
  */
 @Injectable()
 export class ImageValidationPipe implements PipeTransform {
-  constructor(private readonly configService: ConfigService) {}
+  private readonly allowedMimeTypes: Set<string>;
+
+  constructor(private readonly configService: ConfigService) {
+    this.allowedMimeTypes = new Set(
+      this.configService.get('ALLOWED_IMAGE_MIME_TYPES'),
+    );
+  }
 
   async transform(value: unknown): Promise<unknown> {
     const maxFileSize =
       this.configService.get('MAX_IMAGE_UPLOAD_SIZE_MB') * 1024 * 1024;
-    const allowedMimeTypes = this.configService.get('ALLOWED_IMAGE_MIME_TYPES');
 
     if (Buffer.isBuffer(value)) {
-      await this.validateBuffer(value, maxFileSize, allowedMimeTypes);
+      await this.validateBuffer(value, maxFileSize);
     } else if (typeof value === 'string') {
-      this.validateString(value, maxFileSize, allowedMimeTypes);
+      this.validateString(value, maxFileSize);
     }
 
     return value;
@@ -58,21 +63,16 @@ export class ImageValidationPipe implements PipeTransform {
   private async validateBuffer(
     value: Buffer,
     maxFileSize: number,
-    allowedMimeTypes: string[],
   ): Promise<void> {
     this.ensureBufferWithinSize(value, maxFileSize);
 
     const fileType = await detectBufferMime(value);
-    if (!fileType || !allowedMimeTypes.includes(fileType)) {
+    if (!fileType || !this.allowedMimeTypes.has(fileType)) {
       throw new BadRequestException('Invalid image type.');
     }
   }
 
-  private validateString(
-    value: string,
-    maxFileSize: number,
-    allowedMimeTypes: string[],
-  ): void {
+  private validateString(value: string, maxFileSize: number): void {
     if (value.length > 10 * 1024 * 1024) {
       throw new BadRequestException('Base64 image string is too large.');
     }
@@ -82,7 +82,7 @@ export class ImageValidationPipe implements PipeTransform {
     }
 
     const { mimeType, base64Data } = this.parseImageDataUri(value);
-    if (!allowedMimeTypes.includes(mimeType)) {
+    if (!this.allowedMimeTypes.has(mimeType)) {
       throw new BadRequestException('Invalid image type.');
     }
 

--- a/src/common/utils/log-redactor.utility.spec.ts
+++ b/src/common/utils/log-redactor.utility.spec.ts
@@ -19,7 +19,23 @@ describe('LogRedactor', () => {
     expect(request.headers.authorization).toBe('Bearer secret-token');
   });
 
-  it('keeps headers unchanged when no authorisation header exists', () => {
+  it('redacts x-api-key header without mutating the original request', () => {
+    const request = {
+      headers: {
+        'x-api-key': 'abt_secret-key-value',
+        'x-request-id': 'request-id',
+      },
+    } as unknown as IncomingMessage;
+
+    const redacted = LogRedactor.redactRequest(request);
+
+    expect(redacted).not.toBe(request);
+    expect(redacted.headers).not.toBe(request.headers);
+    expect(redacted.headers['x-api-key']).toBe('[REDACTED]');
+    expect(request.headers['x-api-key']).toBe('abt_secret-key-value');
+  });
+
+  it('keeps headers unchanged when no sensitive header exists', () => {
     const request = {
       headers: {
         'x-request-id': 'request-id',

--- a/src/common/utils/log-redactor.utility.ts
+++ b/src/common/utils/log-redactor.utility.ts
@@ -12,8 +12,8 @@ export const LogRedactor = {
   /**
    * Clones the request object and redacts sensitive headers.
    *
-   * Creates a shallow copy of the incoming HTTP request and removes or masks
-   * sensitive headers such as authorization tokens to prevent them from
+   * Creates a shallow copy of the incoming HTTP request and masks sensitive
+   * headers such as authorization and x-api-key to prevent them from
    * appearing in log files.
    * @param {IncomingMessage} request - The incoming HTTP request.
    * @returns {IncomingMessage} A cloned and redacted request object safe for
@@ -26,6 +26,9 @@ export const LogRedactor = {
     clonedRequest.headers = { ...request.headers };
     if (clonedRequest.headers.authorization) {
       clonedRequest.headers.authorization = 'Bearer <redacted>';
+    }
+    if (clonedRequest.headers['x-api-key']) {
+      clonedRequest.headers['x-api-key'] = '[REDACTED]';
     }
     return clonedRequest;
   },

--- a/src/common/zod-validation.pipe.spec.ts
+++ b/src/common/zod-validation.pipe.spec.ts
@@ -3,6 +3,19 @@ import * as z from 'zod';
 
 import { ZodValidationPipe } from './zod-validation.pipe.js';
 
+/**
+ * Creates a mock ConfigService for testing with a given NODE_ENV value.
+ * @param {string} nodeEnvironment - The NODE_ENV value the mock should return.
+ * @returns {{ get: (key: string) => (string | undefined) }} A mock ConfigService object.
+ */
+function createMockConfigService(nodeEnvironment: string): {
+  get: (key: string) => string | undefined;
+} {
+  return {
+    get: (key: string) => (key === 'NODE_ENV' ? nodeEnvironment : undefined),
+  };
+}
+
 describe('ZodValidationPipe', () => {
   const schema = z.object({
     name: z.string(),
@@ -11,7 +24,12 @@ describe('ZodValidationPipe', () => {
   let pipe: ZodValidationPipe;
 
   beforeEach(() => {
-    pipe = new ZodValidationPipe(schema);
+    pipe = new ZodValidationPipe(
+      schema,
+      createMockConfigService(
+        'test',
+      ) as unknown as import('../config/config.service.js').ConfigService,
+    );
   });
 
   it('should be defined', () => {
@@ -46,7 +64,12 @@ describe('ZodValidationPipe', () => {
     let arrayPipe: ZodValidationPipe;
 
     beforeEach(() => {
-      arrayPipe = new ZodValidationPipe(arraySchema);
+      arrayPipe = new ZodValidationPipe(
+        arraySchema,
+        createMockConfigService(
+          'test',
+        ) as unknown as import('../config/config.service.js').ConfigService,
+      );
     });
 
     it('should validate a valid array', () => {
@@ -96,7 +119,12 @@ describe('ZodValidationPipe', () => {
     let nestedPipe: ZodValidationPipe;
 
     beforeEach(() => {
-      nestedPipe = new ZodValidationPipe(nestedSchema);
+      nestedPipe = new ZodValidationPipe(
+        nestedSchema,
+        createMockConfigService(
+          'test',
+        ) as unknown as import('../config/config.service.js').ConfigService,
+      );
     });
 
     it('should handle nested validation schemas with valid data', () => {
@@ -146,6 +174,9 @@ describe('ZodValidationPipe', () => {
     });
     const pipeWithMultipleErrors = new ZodValidationPipe(
       schemaWithMultipleErrors,
+      createMockConfigService(
+        'development',
+      ) as unknown as import('../config/config.service.js').ConfigService,
     );
 
     const invalidData = {
@@ -153,17 +184,12 @@ describe('ZodValidationPipe', () => {
       password: 'short',
     };
 
-    const originalNodeEnvironment = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
-
     let thrownError: unknown;
     try {
       pipeWithMultipleErrors.transform(invalidData, {} as ArgumentMetadata);
     } catch (error) {
       thrownError = error;
     }
-
-    process.env.NODE_ENV = originalNodeEnvironment;
     expect(thrownError).toBeInstanceOf(BadRequestException);
     const response = (
       thrownError as BadRequestException
@@ -188,10 +214,12 @@ describe('ZodValidationPipe', () => {
         message: 'Invalid API Key format',
       }),
     });
-    const sensitivePipe = new ZodValidationPipe(sensitiveSchema);
-
-    const originalNodeEnvironment = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+    const sensitivePipe = new ZodValidationPipe(
+      sensitiveSchema,
+      createMockConfigService(
+        'production',
+      ) as unknown as import('../config/config.service.js').ConfigService,
+    );
 
     let productionError: unknown;
     try {
@@ -209,7 +237,6 @@ describe('ZodValidationPipe', () => {
     // In production, specific error messages should be generic or sanitised
     expect(response.errors[0].message).not.toContain('Invalid API Key format');
     expect(response.errors[0].message).toEqual('Invalid input'); // Zod's default for refined errors
-    process.env.NODE_ENV = originalNodeEnvironment;
   });
 });
 

--- a/src/common/zod-validation.pipe.ts
+++ b/src/common/zod-validation.pipe.ts
@@ -7,6 +7,8 @@ import {
 } from '@nestjs/common';
 import type { ZodType } from 'zod';
 
+import { ConfigService } from '../config/config.service.js';
+
 /**
  * A custom validation pipe that uses Zod schemas to validate incoming data.
  * This pipe is designed to be used with NestJS and implements the `PipeTransform` interface.
@@ -16,7 +18,7 @@ import type { ZodType } from 'zod';
  *   name: z.string(),
  *   age: z.number(),
  * });
- * const validationPipe = new ZodValidationPipe(schema);
+ * const validationPipe = new ZodValidationPipe(schema, configService);
  * ```
  * @remarks
  * - If the schema is not provided, the pipe will simply return the input value without validation.
@@ -24,6 +26,7 @@ import type { ZodType } from 'zod';
  * - In non-production mode, detailed validation issues are logged and returned.
  * @class
  * @param schema - The Zod schema used for validation.
+ * @param configService - The configuration service for accessing environment settings.
  * @function transform
  * Validates the input value against the provided Zod schema.
  * If validation fails, it throws a `BadRequestException` with the validation errors.
@@ -36,7 +39,10 @@ import type { ZodType } from 'zod';
 export class ZodValidationPipe implements PipeTransform {
   private readonly logger = new Logger(ZodValidationPipe.name);
 
-  constructor(private schema?: ZodType) {}
+  constructor(
+    private schema?: ZodType,
+    private readonly configService?: ConfigService,
+  ) {}
 
   transform(value: unknown, metadata: ArgumentMetadata): unknown {
     if (!this.schema) {
@@ -50,8 +56,9 @@ export class ZodValidationPipe implements PipeTransform {
     }
 
     const error = result.error;
+    const nodeEnvironment = this.configService?.get('NODE_ENV');
     const errors =
-      process.env.NODE_ENV === 'production'
+      nodeEnvironment === 'production'
         ? [{ message: 'Invalid input' }]
         : error.issues.map((issue) => ({
             message: issue.message,

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -129,7 +129,7 @@ describe('ConfigService', () => {
       expect(service.get('APP_NAME')).toBe('TestAppNameFromDotEnv');
     });
 
-    it('should prioritize process.env over .env file', async () => {
+    it('should prioritise process.env over .env file', async () => {
       // Mock .env file existence and content
       mockExistsSync.mockImplementation((filePath: PathLike) => {
         return normalisePath(filePath).includes('.env');

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -47,9 +47,9 @@ export class ConfigService {
     );
 
     // envFilePath is constructed from cwd and a fixed filename, safe to use
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- authorised: fixed, non-user-controlled filename; see docs/development/linter-overrides.md
     if (fs.existsSync(environmentFilePath)) {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- authorised: fixed, non-user-controlled filename; see docs/development/linter-overrides.md
       loadedEnvironment = dotenv.parse(fs.readFileSync(environmentFilePath));
     }
 
@@ -74,7 +74,7 @@ export class ConfigService {
    */
   get<T extends keyof Config>(key: T): Config[T] {
     // `key` is constrained to validated schema keys, so this access is not user-controlled.
-    // eslint-disable-next-line security/detect-object-injection
+    // eslint-disable-next-line security/detect-object-injection -- authorised: key constrained to keyof Config (typed, validated schema); see docs/development/linter-overrides.md
     return this.config[key];
   }
 

--- a/src/config/environment.schema.ts
+++ b/src/config/environment.schema.ts
@@ -40,67 +40,64 @@ export const DEFAULT_API_KEY_PREFIX = 'abt_';
  * @property {number} LLM_MAX_RETRIES - The maximum number of retry attempts for LLM rate limit errors.
  * @property {string} [LOG_FILE] - The optional path to a log file for E2E testing.
  */
-export const configSchema = z
-  .object({
-    NODE_ENV: z
-      .enum(['development', 'production', 'test'])
-      .default('production'),
-    PORT: z.coerce.number().int().min(1).max(65535).default(3000),
-    APP_NAME: z.string().default('Assessment Bot LLM Service'),
-    APP_VERSION: z.string().optional(),
-    API_KEY_PREFIX: z
-      .string()
-      .regex(/^[A-Za-z0-9_-]+$/)
-      .default(DEFAULT_API_KEY_PREFIX),
-    API_KEYS: z
-      .string()
-      .optional()
-      .transform((value) =>
-        value === undefined ? undefined : value.split(',').map((s) => s.trim()),
-      ),
-    MAX_IMAGE_UPLOAD_SIZE_MB: z.coerce.number().int().min(0).default(1),
-    ALLOWED_IMAGE_MIME_TYPES: z
-      .string()
-      .default('image/png')
-      .transform((value) => value.split(',').map((s) => s.trim())),
-    GEMINI_API_KEY: z.string().min(1),
-    LOG_LEVEL: z
-      .enum(['info', 'error', 'warn', 'debug', 'verbose', 'fatal'])
-      .default('info'),
-    THROTTLER_TTL: z.coerce.number().int().min(0).default(10000),
-    UNAUTHENTICATED_THROTTLER_LIMIT: z.coerce.number().int().min(0).default(10),
-    AUTHENTICATED_THROTTLER_LIMIT: z.coerce.number().int().min(0).default(90), // A full 3 activities from a full class of submissions at once.
-    LLM_BACKOFF_BASE_MS: z.coerce.number().int().min(100).default(1000), // Minimum 100ms, default 1 second
-    LLM_MAX_RETRIES: z.coerce.number().int().min(0).default(3), // Default 3 retries
-    LOG_FILE: z.string().optional(),
-  })
-  .superRefine((data, context) => {
-    // Validation is a no-op when API_KEYS is undefined so the compile-time
-    // throttler.config.ts parse of bare process.env stays valid.
-    // Only a present-but-malformed API_KEYS is a hard error (fail-fast per SPEC decision #8).
-    if (data.API_KEYS === undefined) return;
+export const configObjectSchema = z.object({
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('production'),
+  PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+  APP_NAME: z.string().default('Assessment Bot LLM Service'),
+  APP_VERSION: z.string().optional(),
+  API_KEY_PREFIX: z
+    .string()
+    .regex(/^[A-Za-z0-9_-]+$/)
+    .default(DEFAULT_API_KEY_PREFIX),
+  API_KEYS: z
+    .string()
+    .optional()
+    .transform((value) =>
+      value === undefined ? undefined : value.split(',').map((s) => s.trim()),
+    ),
+  MAX_IMAGE_UPLOAD_SIZE_MB: z.coerce.number().int().min(0).default(1),
+  ALLOWED_IMAGE_MIME_TYPES: z
+    .string()
+    .default('image/png')
+    .transform((value) => value.split(',').map((s) => s.trim())),
+  GEMINI_API_KEY: z.string().min(1),
+  LOG_LEVEL: z
+    .enum(['info', 'error', 'warn', 'debug', 'verbose', 'fatal'])
+    .default('info'),
+  THROTTLER_TTL: z.coerce.number().int().min(0).default(10000),
+  UNAUTHENTICATED_THROTTLER_LIMIT: z.coerce.number().int().min(0).default(10),
+  AUTHENTICATED_THROTTLER_LIMIT: z.coerce.number().int().min(0).default(90), // A full 3 activities from a full class of submissions at once.
+  LLM_BACKOFF_BASE_MS: z.coerce.number().int().min(100).default(1000), // Minimum 100ms, default 1 second
+  LLM_MAX_RETRIES: z.coerce.number().int().min(0).default(3), // Default 3 retries
+  LOG_FILE: z.string().optional(),
+});
+export const configSchema = configObjectSchema.superRefine((data, context) => {
+  // Validation is a no-op when API_KEYS is undefined so the compile-time
+  // throttler.config.ts parse of bare process.env stays valid.
+  // Only a present-but-malformed API_KEYS is a hard error (fail-fast per SPEC decision #8).
+  if (data.API_KEYS === undefined) return;
 
-    for (const entry of data.API_KEYS) {
-      if (!entry.startsWith(data.API_KEY_PREFIX)) {
-        context.addIssue({
-          code: 'custom',
-          message: 'Invalid API key format',
-          path: ['API_KEYS'],
-        });
-        return;
-      }
-
-      const body = entry.slice(data.API_KEY_PREFIX.length);
-      if (!z.base64url().length(32).safeParse(body).success) {
-        context.addIssue({
-          code: 'custom',
-          message: 'Invalid API key format',
-          path: ['API_KEYS'],
-        });
-        return;
-      }
+  for (const entry of data.API_KEYS) {
+    if (!entry.startsWith(data.API_KEY_PREFIX)) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Invalid API key format',
+        path: ['API_KEYS'],
+      });
+      return;
     }
-  });
+
+    const body = entry.slice(data.API_KEY_PREFIX.length);
+    if (!z.base64url().length(32).safeParse(body).success) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Invalid API key format',
+        path: ['API_KEYS'],
+      });
+      return;
+    }
+  }
+});
 
 /**
  * Represents the inferred TypeScript type from the `configSchema`.

--- a/src/config/environment.schema.ts
+++ b/src/config/environment.schema.ts
@@ -38,6 +38,7 @@ export const DEFAULT_API_KEY_PREFIX = 'abt_';
  * @property {number} AUTHENTICATED_THROTTLER_LIMIT - The maximum number of requests for authenticated routes within the TTL window.
  * @property {number} LLM_BACKOFF_BASE_MS - The base backoff time in milliseconds for LLM rate limit retries.
  * @property {number} LLM_MAX_RETRIES - The maximum number of retry attempts for LLM rate limit errors.
+ * @property {string} [LOG_FILE] - The optional path to a log file for E2E testing.
  */
 export const configSchema = z
   .object({
@@ -71,6 +72,7 @@ export const configSchema = z
     AUTHENTICATED_THROTTLER_LIMIT: z.coerce.number().int().min(0).default(90), // A full 3 activities from a full class of submissions at once.
     LLM_BACKOFF_BASE_MS: z.coerce.number().int().min(100).default(1000), // Minimum 100ms, default 1 second
     LLM_MAX_RETRIES: z.coerce.number().int().min(0).default(3), // Default 3 retries
+    LOG_FILE: z.string().optional(),
   })
   .superRefine((data, context) => {
     // Validation is a no-op when API_KEYS is undefined so the compile-time

--- a/src/config/throttler.config.ts
+++ b/src/config/throttler.config.ts
@@ -1,6 +1,6 @@
 import { ThrottlerModuleOptions } from '@nestjs/throttler';
 
-import { configSchema } from './environment.schema.js';
+import { configObjectSchema } from './environment.schema.js';
 
 /**
  * @file Configures the application's rate-limiting (throttling) settings.
@@ -12,7 +12,9 @@ import { configSchema } from './environment.schema.js';
  * NestJS decorators, such as `@Throttle()`, are executed when the application code is compiled, not when it runs.
  * This means they cannot access runtime-injected providers like `ConfigService` to get configuration values.
  *
- * To solve this, we import the shared `configSchema` and use it to parse `process.env` directly in this file.
+ * To solve this, we import the shared `configObjectSchema` (the pre-`superRefine`
+ * object schema) and pick only the throttler-related keys to parse `process.env`
+ * directly in this file.
  * This ensures that our rate-limiting values are validated with the same rules as the rest of the application's
  * configuration, but are available at compile time for the decorators to use.
  *
@@ -20,8 +22,16 @@ import { configSchema } from './environment.schema.js';
  * while keeping the validation logic centralised in `environment.schema.ts`.
  */
 
-// 1. Validate environment variables at compile time using the shared Zod schema.
-const validatedEnvironment = configSchema.parse(process.env);
+// 1. Validate only the throttler-related environment variables at compile
+//    time. We intentionally pick a subset of the shared schema so that
+//    unrelated required values (e.g. GEMINI_API_KEY) do not need to be present
+//    for the throttler configuration to load.
+const throttlerSchema = configObjectSchema.pick({
+  THROTTLER_TTL: true,
+  UNAUTHENTICATED_THROTTLER_LIMIT: true,
+  AUTHENTICATED_THROTTLER_LIMIT: true,
+});
+const validatedEnvironment = throttlerSchema.parse(process.env);
 
 // 2. Extract the validated throttler values into constants.
 const throttlerTtl = validatedEnvironment.THROTTLER_TTL;

--- a/src/llm/gemini.service.spec.ts
+++ b/src/llm/gemini.service.spec.ts
@@ -117,7 +117,6 @@ describe('GeminiService', () => {
       expect(mockGenerateContent).toHaveBeenCalledWith({
         model: 'gemini-2.5-flash',
         contents: [
-          '',
           { inlineData: { mimeType: 'image/png', data: 'test-data' } },
         ],
         config: {

--- a/src/llm/gemini.service.ts
+++ b/src/llm/gemini.service.ts
@@ -52,7 +52,11 @@ export class GeminiService extends LLMService {
     this.logPayload(payload, contents);
 
     try {
-      return await this.generateAndParseResponse(payload);
+      return await this.generateAndParseResponse(
+        payload,
+        modelParameters,
+        contents,
+      );
     } catch (error) {
       const error_ = error as {
         status?: number;
@@ -147,9 +151,7 @@ export class GeminiService extends LLMService {
 
   private logPayload(payload: LlmPayload, contents: (string | Part)[]): void {
     if (this.isStringPromptPayload(payload)) {
-      this.geminiLogger.debug(
-        `String payload being sent: ${JSON.stringify(contents, null, 2)}`,
-      );
+      this.geminiLogger.debug({ contents }, 'String payload being sent');
     } else if (this.isImagePromptPayload(payload)) {
       this.geminiLogger.debug(
         `Image payload being sent with ${contents.length} content items`,
@@ -165,6 +167,9 @@ export class GeminiService extends LLMService {
    * Builds the Gemini request and parses the response into a validated
    * LlmResponse.
    * @param {LlmPayload} payload The payload to send.
+   * @param {GeminiRequest} modelParameters The pre-built model parameters
+   *   (model name and generation config).
+   * @param {(string | Part)[]} contents The pre-built content parts to send.
    * @returns {Promise<LlmResponse>} A validated assessment response.
    * @remarks
    * - The response text is read via the new SDK's `result.text` getter (the
@@ -174,9 +179,10 @@ export class GeminiService extends LLMService {
    */
   private async generateAndParseResponse(
     payload: LlmPayload,
+    modelParameters: GeminiRequest,
+    contents: (string | Part)[],
   ): Promise<LlmResponse> {
-    const { model, config } = this.buildModelParams(payload);
-    const contents = this.buildContents(payload);
+    const { model, config } = modelParameters;
     const result = await this.client.models.generateContent({
       model,
       contents,
@@ -187,9 +193,7 @@ export class GeminiService extends LLMService {
     this.geminiLogger.debug(`Raw response from Gemini: \n\n${responseText}`);
 
     const parsedJson: unknown = this.jsonParserUtility.parse(responseText);
-    this.geminiLogger.debug(
-      `Parsed JSON response: ${JSON.stringify(parsedJson, null, 2)}`,
-    );
+    this.geminiLogger.debug({ parsedJson }, 'Parsed JSON response');
 
     const dataToValidate: unknown = Array.isArray(parsedJson)
       ? (parsedJson as unknown[])[0]

--- a/src/llm/gemini.service.ts
+++ b/src/llm/gemini.service.ts
@@ -121,7 +121,7 @@ export class GeminiService extends LLMService {
     if (this.isImagePromptPayload(payload)) {
       const { images } = payload;
       const imageParts = this.mapImageParts(images);
-      return ['', ...imageParts];
+      return imageParts;
     }
     if (this.isStringPromptPayload(payload)) {
       return [payload.user];
@@ -192,7 +192,10 @@ export class GeminiService extends LLMService {
     });
     const responseText = result.text ?? '';
 
-    this.geminiLogger.debug(`Raw response from Gemini: \n\n${responseText}`);
+    // Pass the raw value as a structured field so pino serialises it lazily
+    // only when the debug level is enabled (avoids an unconditional, potentially
+    // large string concatenation on the hot path).
+    this.geminiLogger.debug({ responseText }, 'Raw response from Gemini');
 
     const parsedJson: unknown = this.jsonParserUtility.parse(responseText);
     this.geminiLogger.debug({ parsedJson }, 'Parsed JSON response');

--- a/src/llm/gemini.service.ts
+++ b/src/llm/gemini.service.ts
@@ -76,7 +76,9 @@ export class GeminiService extends LLMService {
         this.isErrorObject(error) ? error.stack : undefined,
       );
       if (error instanceof ZodError) {
-        this.logger.error('Zod validation failed', error.issues);
+        this.logger.error(
+          `Zod validation failed: ${JSON.stringify(error.issues)}`,
+        );
         throw error;
       }
 

--- a/src/llm/llm.module.spec.ts
+++ b/src/llm/llm.module.spec.ts
@@ -29,10 +29,10 @@ const mockConfigService = {
 /**
  * A mock implementation of a JSON parser utility for testing purposes.
  *
- * This mock object contains a `parse` method that simulates the behavior of
+ * This mock object contains a `parse` method that simulates the behaviour of
  * parsing a JSON string into a JavaScript object. The `parse` method is
  * implemented using Vitest's `vi.fn` to allow tracking calls and providing custom
- * behavior during tests.
+ * behaviour during tests.
  * @property {Mock} parse - A Vitest mock function that takes a JSON string
  * as input and returns the parsed JavaScript object.
  */

--- a/src/llm/llm.service.interface.spec.ts
+++ b/src/llm/llm.service.interface.spec.ts
@@ -1,0 +1,272 @@
+import { LLMService, LlmPayload } from './llm.service.interface.js';
+import { LlmResponse } from './types.js';
+import { ConfigService } from '../config/config.service.js';
+
+// ---------------------------------------------------------------------------
+// Test subclass that exposes private error-detection helpers for unit testing
+// ---------------------------------------------------------------------------
+class ExposedLLMService extends LLMService {
+  constructor(configService: ConfigService) {
+    super(configService);
+  }
+
+  public exposeIsResourceExhaustedError(error: unknown): boolean {
+    return (
+      this as unknown as { isResourceExhaustedError(error_: unknown): boolean }
+    ).isResourceExhaustedError(error);
+  }
+
+  public exposeIsRateLimitError(error: unknown): boolean {
+    return (
+      this as unknown as { isRateLimitError(error_: unknown): boolean }
+    ).isRateLimitError(error);
+  }
+
+  public exposeExtractErrorStatusCode(error: unknown): number | undefined {
+    return (
+      this as unknown as {
+        extractErrorStatusCode(error_: unknown): number | undefined;
+      }
+    ).extractErrorStatusCode(error);
+  }
+
+  /**
+   * Satisfy the abstract contract -- never called in these tests.
+   * @param _payload - The LLM payload (unused).
+   */
+  protected async _sendInternal(_payload: LlmPayload): Promise<LlmResponse> {
+    throw new Error('Not implemented');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory helpers
+// ---------------------------------------------------------------------------
+/**
+ * Creates a test instance of ExposedLLMService with a mocked ConfigService.
+ * @returns A configured ExposedLLMService instance.
+ */
+function createService(): ExposedLLMService {
+  const configService = {
+    get: vi.fn((key: string) => {
+      if (key === 'LLM_MAX_RETRIES') return '2';
+      if (key === 'LLM_BACKOFF_BASE_MS') return '100';
+      return null;
+    }),
+  } as unknown as ConfigService;
+
+  return new ExposedLLMService(configService);
+}
+
+// ---------------------------------------------------------------------------
+// extractErrorStatusCode tests  (M2 — broaden detection)
+// ---------------------------------------------------------------------------
+describe('extractErrorStatusCode', () => {
+  let service: ExposedLLMService;
+
+  beforeEach(() => {
+    service = createService();
+  });
+
+  it('returns undefined for null / non-object', () => {
+    expect(service.exposeExtractErrorStatusCode(null)).toBeUndefined();
+    expect(service.exposeExtractErrorStatusCode('string')).toBeUndefined();
+    expect(service.exposeExtractErrorStatusCode(undefined)).toBeUndefined();
+  });
+
+  it('reads numeric status property', () => {
+    expect(service.exposeExtractErrorStatusCode({ status: 429 })).toBe(429);
+    expect(service.exposeExtractErrorStatusCode({ status: 500 })).toBe(500);
+  });
+
+  it('reads numeric statusCode property', () => {
+    expect(service.exposeExtractErrorStatusCode({ statusCode: 429 })).toBe(429);
+  });
+
+  it('reads numeric code property', () => {
+    expect(service.exposeExtractErrorStatusCode({ code: 429 })).toBe(429);
+  });
+
+  it('reads string status that parses to a number', () => {
+    expect(service.exposeExtractErrorStatusCode({ status: '429' })).toBe(429);
+  });
+
+  it('reads response.status from nested response object', () => {
+    expect(
+      service.exposeExtractErrorStatusCode({ response: { status: 429 } }),
+    ).toBe(429);
+  });
+
+  it('reads error.status from nested error object', () => {
+    expect(
+      service.exposeExtractErrorStatusCode({
+        error: { status: 429 },
+      }),
+    ).toBe(429);
+  });
+
+  it('reads error.code from nested error object', () => {
+    expect(
+      service.exposeExtractErrorStatusCode({
+        error: { code: 429 },
+      }),
+    ).toBe(429);
+  });
+
+  it('prefers direct status over nested error.status', () => {
+    expect(
+      service.exposeExtractErrorStatusCode({
+        status: 500,
+        error: { status: 429 },
+      }),
+    ).toBe(500);
+  });
+
+  it('returns undefined when no status-like property exists', () => {
+    expect(
+      service.exposeExtractErrorStatusCode({ foo: 'bar' }),
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isResourceExhaustedError tests  (M2)
+// ---------------------------------------------------------------------------
+describe('isResourceExhaustedError', () => {
+  let service: ExposedLLMService;
+
+  beforeEach(() => {
+    service = createService();
+  });
+
+  it('returns true for 429 with resource_exhausted message', () => {
+    const error = new Error('RESOURCE_EXHAUSTED: Quota exceeded');
+    (error as unknown as Record<string, unknown>).status = 429;
+    expect(service.exposeIsResourceExhaustedError(error)).toBe(true);
+  });
+
+  it('returns true for 429 with quota exceeded message', () => {
+    const error = new Error('API quota exceeded for this project');
+    (error as unknown as Record<string, unknown>).status = 429;
+    expect(service.exposeIsResourceExhaustedError(error)).toBe(true);
+  });
+
+  it('returns true when error.status is the string "RESOURCE_EXHAUSTED"', () => {
+    expect(
+      service.exposeIsResourceExhaustedError({ status: 'RESOURCE_EXHAUSTED' }),
+    ).toBe(true);
+  });
+
+  it('returns true when error.code is the string "RESOURCE_EXHAUSTED"', () => {
+    expect(
+      service.exposeIsResourceExhaustedError({ code: 'RESOURCE_EXHAUSTED' }),
+    ).toBe(true);
+  });
+
+  it('returns true when nested error.status is "RESOURCE_EXHAUSTED"', () => {
+    expect(
+      service.exposeIsResourceExhaustedError({
+        error: { status: 'RESOURCE_EXHAUSTED' },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when nested error.code is "RESOURCE_EXHAUSTED"', () => {
+    expect(
+      service.exposeIsResourceExhaustedError({
+        error: { code: 'RESOURCE_EXHAUSTED' },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for 429 with plain rate-limit message', () => {
+    const error = new Error('Rate limit exceeded');
+    (error as unknown as Record<string, unknown>).status = 429;
+    expect(service.exposeIsResourceExhaustedError(error)).toBe(false);
+  });
+
+  it('returns false for 500 errors', () => {
+    const error = new Error('Server error');
+    (error as unknown as Record<string, unknown>).status = 500;
+    expect(service.exposeIsResourceExhaustedError(error)).toBe(false);
+  });
+
+  it('returns false for non-error objects', () => {
+    expect(service.exposeIsResourceExhaustedError('string error')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isRateLimitError tests  (M2 — mutually consistent with
+//   isResourceExhaustedError)
+// ---------------------------------------------------------------------------
+describe('isRateLimitError', () => {
+  let service: ExposedLLMService;
+
+  beforeEach(() => {
+    service = createService();
+  });
+
+  it('returns true for 429 with rate limit message', () => {
+    const error = new Error('Rate limit exceeded');
+    (error as unknown as Record<string, unknown>).status = 429;
+    expect(service.exposeIsRateLimitError(error)).toBe(true);
+  });
+
+  it('returns true for numeric 429 with no specific message', () => {
+    const error = new Error('Too Many Requests');
+    (error as unknown as Record<string, unknown>).status = 429;
+    expect(service.exposeIsRateLimitError(error)).toBe(true);
+  });
+
+  it('returns true for "too many requests" message without 429 status', () => {
+    const error = new Error('Too many requests, please slow down');
+    expect(service.exposeIsRateLimitError(error)).toBe(true);
+  });
+
+  it('returns true for "rate limit" message without 429 status', () => {
+    expect(service.exposeIsRateLimitError(new Error('Rate limit hit'))).toBe(
+      true,
+    );
+  });
+
+  it('returns true when error.status is the string "RATE_LIMIT_EXCEEDED"', () => {
+    expect(
+      service.exposeIsRateLimitError({ status: 'RATE_LIMIT_EXCEEDED' }),
+    ).toBe(true);
+  });
+
+  it('returns true when error.status is the string "429"', () => {
+    expect(service.exposeIsRateLimitError({ status: '429' })).toBe(true);
+  });
+
+  it('returns true when nested error.status is "RATE_LIMIT_EXCEEDED"', () => {
+    expect(
+      service.exposeIsRateLimitError({
+        error: { status: 'RATE_LIMIT_EXCEEDED' },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for resource exhausted errors', () => {
+    const error = new Error('RESOURCE_EXHAUSTED: Free tier quota exceeded');
+    (error as unknown as Record<string, unknown>).status = 429;
+    expect(service.exposeIsRateLimitError(error)).toBe(false);
+  });
+
+  it('returns false when error.status is "RESOURCE_EXHAUSTED" string', () => {
+    expect(
+      service.exposeIsRateLimitError({ status: 'RESOURCE_EXHAUSTED' }),
+    ).toBe(false);
+  });
+
+  it('returns false for non-rate-limit 500 errors', () => {
+    const error = new Error('Internal server error');
+    (error as unknown as Record<string, unknown>).status = 500;
+    expect(service.exposeIsRateLimitError(error)).toBe(false);
+  });
+
+  it('returns false for non-error objects without matching patterns', () => {
+    expect(service.exposeIsRateLimitError('string error')).toBe(false);
+  });
+});

--- a/src/llm/llm.service.interface.ts
+++ b/src/llm/llm.service.interface.ts
@@ -210,6 +210,12 @@ export abstract class LLMService {
    * @returns {boolean} True if the error is a resource exhausted error.
    */
   private isResourceExhaustedError(error: unknown): boolean {
+    // Check for gRPC-style string status indicating resource exhaustion
+    // (e.g. error.status === 'RESOURCE_EXHAUSTED') regardless of numeric code.
+    if (this.matchesStringStatus(error, (s) => s === 'resource_exhausted')) {
+      return true;
+    }
+
     // Use the utility function to extract status code from various error formats
     const statusCode = this.extractErrorStatusCode(error);
 
@@ -229,6 +235,43 @@ export abstract class LLMService {
         'quota has been exhausted',
       ];
       return patterns.some((pattern) => message.includes(pattern));
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks whether a string status/code property on the error (or its nested
+   * `.error` object) satisfies a given predicate. This handles gRPC-style
+   * string status codes such as `'RESOURCE_EXHAUSTED'` or `'RATE_LIMIT_EXCEEDED'`.
+   * @param error - The error to inspect.
+   * @param predicate - A function that receives a lower-case string value
+   *   and returns true when it matches the desired status.
+   * @returns True if any recognised status field matches the predicate.
+   */
+  private matchesStringStatus(
+    error: unknown,
+    predicate: (lower: string) => boolean,
+  ): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const error_ = error as Record<string, unknown>;
+
+    const check = (value: unknown): boolean =>
+      typeof value === 'string' && predicate(value.toLowerCase());
+
+    if (check(error_.status) || check(error_.code)) {
+      return true;
+    }
+
+    // Check nested error object (API error response body pattern)
+    if (error_.error && typeof error_.error === 'object') {
+      const inner = error_.error as Record<string, unknown>;
+      if (check(inner.status) || check(inner.code)) {
+        return true;
+      }
     }
 
     return false;
@@ -262,6 +305,17 @@ export abstract class LLMService {
       return false;
     }
 
+    // Check for gRPC-style string status indicating rate limiting
+    // (e.g. error.status === 'RATE_LIMIT_EXCEEDED')
+    if (
+      this.matchesStringStatus(
+        error,
+        (s) => s === 'rate_limit_exceeded' || s === '429',
+      )
+    ) {
+      return true;
+    }
+
     // Use the utility function to extract status code from various error formats
     const statusCode = this.extractErrorStatusCode(error);
     if (statusCode === 429) {
@@ -283,6 +337,9 @@ export abstract class LLMService {
    * Utility function to extract HTTP status code from various error formats.
    *
    * This is designed to work with different LLM SDK error structures.
+   * Recognises numeric `status`, `statusCode`, `code`, `response.status`,
+   * `error.status`, and `error.code`, as well as string values that parse
+   * to a number (e.g. `'429'`).
    * @param {unknown} error The error to extract status code from.
    * @returns {number | undefined} The HTTP status code if found, undefined
    *   otherwise.
@@ -292,25 +349,44 @@ export abstract class LLMService {
       return undefined;
     }
 
-    // Check for status property directly
-    if ('status' in error && typeof error.status === 'number') {
-      return error.status;
-    }
+    const error_ = error as Record<string, unknown>;
 
-    // Check for statusCode property (alternative naming)
-    if ('statusCode' in error && typeof error.statusCode === 'number') {
-      return error.statusCode;
-    }
+    // Coerce a value to a number (handles '429' strings too)
+    const toNumber = (value: unknown): number | undefined => {
+      if (typeof value === 'number' && !Number.isNaN(value)) return value;
+      if (typeof value === 'string') {
+        const parsed = Number(value);
+        if (!Number.isNaN(parsed)) return parsed;
+      }
+      return undefined;
+    };
 
-    // Check for response.status (nested in response object)
+    // Check direct properties in priority order
+    const directStatus: number | undefined =
+      toNumber(error_.status) ??
+      toNumber(error_.statusCode) ??
+      toNumber(error_.code);
+    if (directStatus !== undefined) return directStatus;
+
+    // Check response.status (nested in response object)
     if (
-      'response' in error &&
-      error.response &&
-      typeof error.response === 'object' &&
-      'status' in error.response &&
-      typeof (error.response as Record<string, unknown>).status === 'number'
+      'response' in error_ &&
+      error_.response &&
+      typeof error_.response === 'object'
     ) {
-      return (error.response as Record<string, unknown>).status as number;
+      const responseStatus = toNumber(
+        (error_.response as Record<string, unknown>).status,
+      );
+      if (responseStatus !== undefined) return responseStatus;
+    }
+
+    // Check nested error object (API error response body pattern,
+    // e.g. { error: { code: 429, status: 'RESOURCE_EXHAUSTED' } })
+    if ('error' in error_ && error_.error && typeof error_.error === 'object') {
+      const inner = error_.error as Record<string, unknown>;
+      const innerStatus: number | undefined =
+        toNumber(inner.status) ?? toNumber(inner.code);
+      if (innerStatus !== undefined) return innerStatus;
     }
 
     return undefined;

--- a/src/prompt/image.prompt.spec.ts
+++ b/src/prompt/image.prompt.spec.ts
@@ -1,134 +1,13 @@
-import * as fs from 'node:fs/promises';
-
 import { Logger } from '@nestjs/common';
-import { Mock } from 'vitest';
 
 import { ImagePrompt } from './image.prompt.js';
 import { ImagePromptPayload } from '../llm/llm.service.interface.js';
-
-vi.mock('fs/promises');
 
 describe('ImagePrompt', () => {
   let logger: Logger;
 
   beforeEach(() => {
     logger = new Logger();
-  });
-
-  it('should build a structured payload with text and images', async () => {
-    const inputs = {
-      referenceTask: 'Reference text',
-      studentTask: 'Student text',
-      emptyTask: 'Empty text',
-    };
-    const images = [
-      { path: 'referenceTask.png', mimeType: 'image/png' },
-      { path: 'studentTask.png', mimeType: 'image/png' },
-    ];
-    const template = 'Image system prompt template';
-
-    (fs.readFile as Mock).mockImplementation(
-      (filePath: string, options: { encoding: string }) => {
-        if (
-          filePath.includes('src/prompt/templates/image.system.prompt.md') &&
-          options.encoding === 'utf8'
-        ) {
-          return Promise.resolve(template);
-        }
-        if (filePath.endsWith('.png') && options.encoding === 'base64') {
-          return Promise.resolve('base64data');
-        }
-        return Promise.reject(new Error('File not found'));
-      },
-    );
-
-    const systemPrompt = 'system prompt';
-    const allowed = ['image/png'];
-    const prompt = new ImagePrompt(
-      inputs,
-      logger,
-      allowed,
-      images,
-      systemPrompt,
-    );
-    const message = (await prompt.buildMessage()) as ImagePromptPayload;
-
-    const calls = (fs.readFile as Mock).mock.calls;
-    expect(calls).toEqual(
-      expect.arrayContaining([
-        [expect.stringContaining('referenceTask.png'), { encoding: 'base64' }],
-        [expect.stringContaining('studentTask.png'), { encoding: 'base64' }],
-      ]),
-    );
-
-    // For ImagePrompt, system is passed directly, no template rendering
-    expect(message.system).toBe(systemPrompt);
-    expect(message.images).toEqual([
-      { data: 'base64data', mimeType: 'image/png' },
-      { data: 'base64data', mimeType: 'image/png' },
-    ]);
-  });
-
-  it('should reject images with disallowed MIME types', async () => {
-    const inputs = {
-      referenceTask: 'Reference text',
-      studentTask: 'Student text',
-      emptyTask: 'Empty text',
-    };
-    const images = [
-      { path: 'ref.png', mimeType: 'image/gif' }, // Not allowed by default
-    ];
-    const allowed = ['image/png'];
-    const prompt = new ImagePrompt(inputs, logger, allowed, images);
-    await expect(prompt.readImageFile('ref.png', 'image/gif')).rejects.toThrow(
-      'Disallowed image MIME type',
-    );
-  });
-
-  it('should reject images with missing MIME type', async () => {
-    const inputs = {
-      referenceTask: 'Reference text',
-      studentTask: 'Student text',
-      emptyTask: 'Empty text',
-    };
-    const images = [
-      { path: 'ref.png', mimeType: undefined as unknown as string },
-    ];
-    const allowed = ['image/png'];
-    const prompt = new ImagePrompt(inputs, logger, allowed, images);
-    await expect(
-      prompt.readImageFile('ref.png', undefined as unknown as string),
-    ).rejects.toThrow('Disallowed image MIME type');
-  });
-
-  it('should reject images with path traversal in filename', async () => {
-    const inputs = {
-      referenceTask: 'Reference text',
-      studentTask: 'Student text',
-      emptyTask: 'Empty text',
-    };
-    const images = [{ path: '../ref.png', mimeType: 'image/png' }];
-    const allowed = ['image/png'];
-    const prompt = new ImagePrompt(inputs, logger, allowed, images);
-    await expect(
-      prompt.readImageFile('../ref.png', 'image/png'),
-    ).rejects.toThrow('Invalid image filename');
-  });
-
-  it('should accept allowed MIME types from env', async () => {
-    const inputs = {
-      referenceTask: 'Reference text',
-      studentTask: 'Student text',
-      emptyTask: 'Empty text',
-    };
-    const images = [{ path: 'ref.png', mimeType: 'image/jpeg' }];
-    const allowed = ['image/png', 'image/jpeg'];
-    const prompt = new ImagePrompt(inputs, logger, allowed, images);
-    // Mock fs.readFile to resolve
-    (fs.readFile as Mock).mockResolvedValueOnce('base64data');
-    await expect(prompt.readImageFile('ref.png', 'image/jpeg')).resolves.toBe(
-      'base64data',
-    );
   });
 
   it('should build images from data URIs when no files are provided', async () => {
@@ -138,8 +17,7 @@ describe('ImagePrompt', () => {
       emptyTask: 'data:image/png;base64,EMPTYDATA',
     };
 
-    const allowed = ['image/png'];
-    const prompt = new ImagePrompt(inputs, logger, allowed);
+    const prompt = new ImagePrompt(inputs, logger);
     const message = (await prompt.buildMessage()) as ImagePromptPayload;
 
     expect(message.images).toEqual([
@@ -156,23 +34,30 @@ describe('ImagePrompt', () => {
       emptyTask: 'data:image/png;base64,EMPTYDATA',
     };
 
-    const allowed = ['image/png'];
-    const prompt = new ImagePrompt(inputs, logger, allowed);
+    const prompt = new ImagePrompt(inputs, logger);
 
     await expect(prompt.buildMessage()).rejects.toThrow('Invalid Data URI');
   });
 
-  it('should reject unauthorised absolute paths', async () => {
-    const inputs = {
-      referenceTask: 'Reference text',
-      studentTask: 'Student text',
-      emptyTask: 'Empty text',
-    };
-    const allowed = ['image/png'];
-    const prompt = new ImagePrompt(inputs, logger, allowed, []);
+  it('should handle data URIs resulting from Buffer conversion', async () => {
+    // This simulates the output of PromptFactory's Buffer → data URI conversion.
+    // The factory converts Buffer fields to data URIs using detectBufferMime
+    // before passing them to ImagePrompt, so ImagePrompt only ever sees strings.
+    const base64Data =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+    const dataUri = `data:image/png;base64,${base64Data}`;
 
-    await expect(
-      prompt.readImageFile('/etc/passwd', 'image/png'),
-    ).rejects.toThrow('Unauthorised file path');
+    const inputs = {
+      referenceTask: dataUri,
+      studentTask: dataUri,
+      emptyTask: dataUri,
+    };
+
+    const prompt = new ImagePrompt(inputs, logger);
+    const message = (await prompt.buildMessage()) as ImagePromptPayload;
+
+    expect(message.images).toHaveLength(3);
+    expect(message.images[0].mimeType).toBe('image/png');
+    expect(message.images[0].data).toBe(base64Data);
   });
 });

--- a/src/prompt/image.prompt.ts
+++ b/src/prompt/image.prompt.ts
@@ -1,77 +1,46 @@
-import * as fs from 'node:fs/promises';
-import path from 'node:path';
-
-import { Logger } from '@nestjs/common';
+import { Logger, BadRequestException } from '@nestjs/common';
 
 import { Prompt, PromptInput } from './prompt.base.js';
-import { getCurrentDirname } from '../common/file-utilities.js';
 import { LlmPayload } from '../llm/llm.service.interface.js';
 
 /**
  * Prompt implementation for assessing image-based tasks.
  *
- * This class handles the creation of prompts for image assessment tasks,
- * supporting both file-based images and data URI encoded images. It manages
- * the conversion of image data into formats suitable for LLM processing
- * and implements security measures for file access.
+ * This class handles the creation of prompts for image assessment tasks
+ * using data URI encoded images (including Buffers converted to data URIs
+ * upstream by PromptFactory). It manages the extraction of base64-encoded
+ * image data from data URI strings into formats suitable for LLM processing.
  */
 export class ImagePrompt extends Prompt {
-  private readonly images: { path: string; mimeType: string }[];
-  private readonly allowedMimeTypes: string[];
-
   /**
    * Initialises the ImagePrompt instance with image-specific configuration.
    * @param {PromptInput} inputs - Validated prompt input data containing image
    *   information.
    * @param {Logger} logger - Logger instance for recording image prompt
    *   operations.
-   * @param {string[]} allowedMimeTypes - Array of allowed MIME types for image
-   *   validation, supplied via ConfigService through PromptFactory.
-   * @param {{ path: string; mimeType: string }[]} [images] - Optional array of
-   *   image objects with file paths and MIME types.
    * @param {string} [systemPrompt] - Optional system prompt string providing
    *   context for image assessment.
    */
-  constructor(
-    inputs: PromptInput,
-    logger: Logger,
-    allowedMimeTypes: string[],
-    images?: { path: string; mimeType: string }[],
-    systemPrompt?: string,
-  ) {
+  constructor(inputs: PromptInput, logger: Logger, systemPrompt?: string) {
     super(inputs, logger, undefined, systemPrompt);
-    this.allowedMimeTypes = allowedMimeTypes;
-    this.images = images || [];
   }
 
   /**
    * Builds the LLM payload for an image-based assessment.
    *
    * Creates a payload suitable for multimodal LLMs that can process both
-   * text and images. The method handles two scenarios:
-   * 1. File-based images: reads image files from disk
-   * 2. Data URI images: extracts image data from base64 encoded strings.
+   * text and images. Image data is extracted from data URI strings in the
+   * input fields. The validation pipeline guarantees all image fields contain
+   * valid data URIs (or have been converted from Buffers upstream).
    * @returns {Promise<LlmPayload>} Promise resolving to an LlmPayload
    *   containing system prompt and image data.
    */
   public async buildMessage(): Promise<LlmPayload> {
-    // For image prompts, the user message is a combination of the rendered system prompt
-    // and the structured inputs.
+    this.logger.debug(
+      'Building image payload from data URI inputs in the request.',
+    );
 
-    // Handle the images
-
-    let images: { data: string; mimeType: string }[];
-    if (this.images.length > 0) {
-      this.logger.debug(
-        `Building image payload from ${this.images.length} file-based images.`,
-      );
-      images = await this.buildImagesFromFiles();
-    } else {
-      this.logger.debug(
-        'Building image payload from data URI inputs in the request.',
-      );
-      images = this.buildImagesFromDataUris();
-    }
+    const images = this.buildImagesFromDataUris();
 
     this.logger.log(`Built image payload with ${images.length} images.`);
 
@@ -82,28 +51,6 @@ export class ImagePrompt extends Prompt {
   }
 
   /**
-   * Builds image payload from file paths on the filesystem.
-   *
-   * Reads image files from disk and converts them to base64 format
-   * suitable for LLM processing. This method is used when images
-   * are provided as file references rather than embedded data.
-   * @returns {Promise<{ data: string; mimeType: string }[]>} Promise resolving
-   *   to array of image data and MIME type objects.
-   */
-  private async buildImagesFromFiles(): Promise<
-    { data: string; mimeType: string }[]
-  > {
-    const imagePromises = this.images.map(async (image) => {
-      this.logger.debug(
-        `Reading image file for prompt: ${image.path} (${image.mimeType}).`,
-      );
-      const data = await this.readImageFile(image.path, image.mimeType);
-      return { data, mimeType: image.mimeType };
-    });
-    return Promise.all(imagePromises);
-  }
-
-  /**
    * Builds image payload from data URIs embedded in the input.
    *
    * Extracts base64-encoded image data from data URI strings in the
@@ -111,7 +58,7 @@ export class ImagePrompt extends Prompt {
    * already confirmed all image fields contain valid data URIs.
    * @returns {{ data: string; mimeType: string }[]} Array of image data and
    *   MIME type objects.
-   * @throws {Error} If any data URI is malformed.
+   * @throws {BadRequestException} If any data URI is malformed.
    */
   private buildImagesFromDataUris(): { data: string; mimeType: string }[] {
     // Assumes validation pipeline guarantees all three tasks are valid data URIs
@@ -121,7 +68,9 @@ export class ImagePrompt extends Prompt {
         this.logger.error(
           `Invalid data URI encountered while building image prompt: ${uri.slice(0, 30)}...`,
         );
-        throw new Error(`Invalid Data URI: ${uri.slice(0, 30)}...`);
+        throw new BadRequestException(
+          'Invalid Data URI provided for an image field.',
+        );
       }
       const [, mimeType, data] = match;
       this.logger.debug(
@@ -134,64 +83,5 @@ export class ImagePrompt extends Prompt {
       parseDataUri(this.emptyTask),
       parseDataUri(this.studentTask),
     ];
-  }
-
-  /**
-   * Reads an image file from the specified path and returns its content as a base64-encoded string.
-   * @param {string} imagePath - The relative path to the image file within the
-   *   allowed directory. Path traversal is blocked to ensure security.
-   * @param {string} [mimeType] - The MIME type of the image file. Must be one
-   *   of the allowed MIME types configured in the environment schema. Defaults
-   *   to 'image/png' if not provided.
-   * @returns {Promise<string>} A promise that resolves to the base64-encoded
-   *   content of the image file.
-   * @throws {Error} If the `imagePath` contains path traversal (`..`).
-   * @throws {Error} If the `mimeType` is not allowed based on the configuration.
-   * @throws {Error} If the resolved file path is outside the authorised
-   *   directory.
-   * @remarks
-   * - The method ensures security by validating the file path and MIME type before reading the file.
-   * - The base directory for image files is restricted to `docs/ImplementationPlan/Stage6/ExampleData/ImageTasks`.
-   * - The file path validation prevents unauthorised access to files outside the allowed directory.
-   * - Allowed MIME types are supplied via ConfigService (injected through PromptFactory), not read from process.env.
-   */
-  async readImageFile(imagePath: string, mimeType?: string): Promise<string> {
-    // Security: Only allow reading from the Prompts directory, and block path traversal
-    if (imagePath.includes('..')) {
-      this.logger.warn(`Blocked image path traversal attempt: ${imagePath}.`);
-      throw new Error('Invalid image filename');
-    }
-    if (path.isAbsolute(imagePath)) {
-      this.logger.warn(
-        `Blocked unauthorised absolute image path: ${imagePath}.`,
-      );
-      throw new Error('Unauthorised file path');
-    }
-    // Get allowed MIME types from injected configuration
-    const allowedMimeTypes = this.allowedMimeTypes.map((type) =>
-      type.trim().toLowerCase(),
-    );
-    if (!mimeType || !allowedMimeTypes.includes(mimeType.toLowerCase())) {
-      this.logger.warn(
-        `Blocked image with disallowed MIME type: ${mimeType ?? 'unknown'}.`,
-      );
-      throw new Error('Disallowed image MIME type');
-    }
-    const baseDirectory = path.join(
-      getCurrentDirname(),
-      '../../../docs/ImplementationPlan/Stage6/ExampleData/ImageTasks',
-    );
-    const relativePath = path.join(baseDirectory, imagePath);
-    if (!relativePath.startsWith(baseDirectory)) {
-      this.logger.warn(`Blocked unauthorised image path: ${imagePath}.`);
-      throw new Error('Unauthorised file path');
-    }
-    // Security: Path is validated above, safe to read
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    const data = await fs.readFile(relativePath, { encoding: 'base64' });
-    this.logger.debug(
-      `Read image file ${imagePath} with ${data.length} base64 characters.`,
-    );
-    return data;
   }
 }

--- a/src/prompt/prompt.base.ts
+++ b/src/prompt/prompt.base.ts
@@ -70,9 +70,7 @@ export abstract class Prompt {
   ) {
     this.logger = logger;
     // Prompt constructor received inputs is set to verbose logging because it can output the base64 strings from image prompts, which often isn't particularly helpful for debugging.
-    this.logger.verbose(
-      `Prompt constructor received inputs: ${JSON.stringify(inputs)}`,
-    );
+    this.logger.verbose({ inputs }, 'Prompt constructor received inputs');
     const parsed: PromptInput = PromptInputSchema.parse(inputs);
     this.referenceTask = parsed.referenceTask;
     this.studentTask = parsed.studentTask;

--- a/src/prompt/prompt.factory.spec.ts
+++ b/src/prompt/prompt.factory.spec.ts
@@ -6,6 +6,7 @@ import { PromptFactory } from './prompt.factory.js';
 import { TablePrompt } from './table.prompt.js';
 import { TextPrompt } from './text.prompt.js';
 import { ConfigModule } from '../config/config.module.js';
+import { ImagePromptPayload } from '../llm/llm.service.interface.js';
 import {
   CreateAssessorDto,
   TaskType,
@@ -49,13 +50,12 @@ describe('PromptFactory', () => {
     expect(prompt).toBeInstanceOf(TablePrompt);
   });
 
-  it("should return an ImagePrompt for taskType 'IMAGE'", async () => {
+  it("should return an ImagePrompt for taskType 'IMAGE' with string inputs", async () => {
     const dto: CreateAssessorDto = {
       taskType: TaskType.IMAGE,
       reference: 'ref',
       studentResponse: 'stud',
       template: 'temp',
-      images: [],
     };
     const prompt = await factory.create(dto);
     expect(prompt).toBeInstanceOf(ImagePrompt);
@@ -68,5 +68,62 @@ describe('PromptFactory', () => {
     await expect(factory.create(dto)).rejects.toThrow(
       'Unsupported task type: INVALID',
     );
+  });
+
+  describe('IMAGE Buffer inputs', () => {
+    const pngBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+    let pngBuffer: Buffer;
+
+    beforeAll(() => {
+      pngBuffer = Buffer.from(pngBase64, 'base64');
+    });
+
+    it('should produce valid ImagePrompt with Buffer inputs and correct data URIs', async () => {
+      const dto: CreateAssessorDto = {
+        taskType: TaskType.IMAGE,
+        reference: pngBuffer,
+        studentResponse: pngBuffer,
+        template: pngBuffer,
+      };
+
+      const prompt = await factory.create(dto);
+      expect(prompt).toBeInstanceOf(ImagePrompt);
+
+      const message = (await prompt.buildMessage()) as ImagePromptPayload;
+      expect(message.images).toHaveLength(3);
+
+      // All three images should have detected PNG MIME type and the correct
+      // base64 data
+      for (const image of message.images) {
+        expect(image.mimeType).toBe('image/png');
+        expect(image.data).toBe(pngBase64);
+      }
+    });
+
+    it('should pass Buffer data URIs through buildMessage in the correct order', async () => {
+      // Use distinct buffers so we can verify ordering:
+      // referenceTask (1st), emptyTask/template (2nd), studentTask (3rd)
+      const referenceBase64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+      const templateBase64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+      const studentBase64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42jNkYPgPAADSATABtElncgAAAABJRU5ErkJggg==';
+
+      const dto: CreateAssessorDto = {
+        taskType: TaskType.IMAGE,
+        reference: Buffer.from(referenceBase64, 'base64'),
+        studentResponse: Buffer.from(studentBase64, 'base64'),
+        template: Buffer.from(templateBase64, 'base64'),
+      };
+
+      const prompt = await factory.create(dto);
+      const message = (await prompt.buildMessage()) as ImagePromptPayload;
+
+      expect(message.images[0].data).toBe(referenceBase64);
+      expect(message.images[1].data).toBe(templateBase64);
+      expect(message.images[2].data).toBe(studentBase64);
+    });
   });
 });

--- a/src/prompt/prompt.factory.ts
+++ b/src/prompt/prompt.factory.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { detectBufferMime } from 'mime-detect';
 
 import { ImagePrompt } from './image.prompt.js';
 import { Prompt } from './prompt.base.js';
@@ -59,7 +60,7 @@ export class PromptFactory {
     const systemPrompt = await this.loadSystemPrompt(systemPromptFile);
 
     // Instantiate the appropriate Prompt subclass
-    const prompt = this.instantiatePrompt(
+    const prompt = await this.instantiatePrompt(
       dto,
       inputs,
       userTemplateFile,
@@ -150,15 +151,16 @@ export class PromptFactory {
    * @param {string} [userTemplateFile] - Name of the user template file (if
    *   applicable).
    * @param {string} [systemPrompt] - System prompt content (if applicable).
-   * @returns {Prompt} Configured prompt instance ready for message generation.
+   * @returns {Promise<Prompt>} Promise resolving to a configured prompt
+   *   instance ready for message generation.
    * @throws {Error} If the task type is not supported.
    */
-  private instantiatePrompt(
+  private async instantiatePrompt(
     dto: CreateAssessorDto,
     inputs: unknown,
     userTemplateFile?: string,
     systemPrompt?: string,
-  ): Prompt {
+  ): Promise<Prompt> {
     switch (dto.taskType) {
       case TaskType.TEXT:
         return new TextPrompt(
@@ -175,24 +177,52 @@ export class PromptFactory {
           systemPrompt,
         );
       case TaskType.IMAGE: {
-        const imageInputs = {
-          referenceTask: Buffer.isBuffer(dto.reference)
-            ? dto.reference.toString()
-            : dto.reference,
-          studentTask: Buffer.isBuffer(dto.studentResponse)
-            ? dto.studentResponse.toString()
-            : dto.studentResponse,
-          emptyTask: Buffer.isBuffer(dto.template)
-            ? dto.template.toString()
-            : dto.template,
+        let imageInputs: {
+          referenceTask: string;
+          studentTask: string;
+          emptyTask: string;
         };
-        return new ImagePrompt(
-          imageInputs,
-          this.logger,
-          this.configService.get('ALLOWED_IMAGE_MIME_TYPES'),
-          dto.images,
-          systemPrompt,
-        );
+
+        if (Buffer.isBuffer(dto.reference)) {
+          // superRefine guarantees all three fields are Buffers when one is
+          const [referenceMimeType, studentMimeType, templateMimeType] =
+            await Promise.all([
+              detectBufferMime(dto.reference),
+              detectBufferMime(dto.studentResponse as Buffer),
+              detectBufferMime(dto.template as Buffer),
+            ]);
+
+          if (!referenceMimeType) {
+            throw new BadRequestException(
+              'Unable to detect MIME type for reference image buffer.',
+            );
+          }
+          if (!studentMimeType) {
+            throw new BadRequestException(
+              'Unable to detect MIME type for student response image buffer.',
+            );
+          }
+          if (!templateMimeType) {
+            throw new BadRequestException(
+              'Unable to detect MIME type for template image buffer.',
+            );
+          }
+
+          imageInputs = {
+            referenceTask: `data:${referenceMimeType};base64,${dto.reference.toString('base64')}`,
+            studentTask: `data:${studentMimeType};base64,${(dto.studentResponse as Buffer).toString('base64')}`,
+            emptyTask: `data:${templateMimeType};base64,${(dto.template as Buffer).toString('base64')}`,
+          };
+        } else {
+          // superRefine guarantees all three fields are strings when reference is
+          imageInputs = {
+            referenceTask: dto.reference,
+            studentTask: dto.studentResponse as string,
+            emptyTask: dto.template as string,
+          };
+        }
+
+        return new ImagePrompt(imageInputs, this.logger, systemPrompt);
       }
       default:
         throw new Error('Unsupported task type');

--- a/src/prompt/templates/image.system.prompt.md
+++ b/src/prompt/templates/image.system.prompt.md
@@ -17,8 +17,8 @@ You have been given 2 - 3 images.
 Describe the images you see. Format your descriptions as follows:
 
 Reference Task: {description of the first image}
-Template: {description of the third image}
-Student Submission: {description of the second image}
+Template: {description of the second image}
+Student Submission: {description of the third image}
 
 ## Step 2:
 

--- a/src/v1/assessor/assessor.controller.ts
+++ b/src/v1/assessor/assessor.controller.ts
@@ -1,4 +1,10 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  UseGuards,
+  ArgumentMetadata,
+} from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 
 import { AssessorService } from './assessor.service.js';
@@ -56,18 +62,22 @@ export class AssessorController {
    * For IMAGE task types, this method performs additional validation on the
    * image data using the ImageValidationPipe to ensure proper format, size,
    * and MIME type compliance.
-   * @param {CreateAssessorDto} assessorDto - Validated data transfer object
-   *   containing task details.
+   * @param {unknown} rawBody - The raw request body to be validated.
    * @returns {Promise<LlmResponse>} Promise resolving to LLM assessment
    *   response with scoring and reasoning.
    * @throws {BadRequestException} If validation fails for any field.
    * @throws {UnauthorizedException} If API key authentication fails.
    */
   @Post()
-  async create(
-    @Body(new ZodValidationPipe(assessorDtoSchema))
-    assessorDto: CreateAssessorDto,
-  ): Promise<LlmResponse> {
+  async create(@Body() rawBody: unknown): Promise<LlmResponse> {
+    const validationPipe = new ZodValidationPipe(
+      assessorDtoSchema,
+      this.configService,
+    );
+    const assessorDto = validationPipe.transform(rawBody, {
+      type: 'body',
+    } as ArgumentMetadata) as CreateAssessorDto;
+
     // If taskType is IMAGE, validate image fields using ImageValidationPipe
     if (assessorDto.taskType === 'IMAGE') {
       const imagePipe = new ImageValidationPipe(this.configService);

--- a/src/v1/assessor/assessor.service.spec.ts
+++ b/src/v1/assessor/assessor.service.spec.ts
@@ -173,16 +173,6 @@ describe('AssessorService', () => {
         reference: 'A picture of a cat',
         studentResponse: 'A drawing of a cat',
         template: 'An empty canvas',
-        images: [
-          {
-            mimeType: 'image/png',
-            path: 'reference-image.png',
-          },
-          {
-            mimeType: 'image/png',
-            path: 'student-image.png',
-          },
-        ],
       };
 
       const mockMultimodalPayload = {

--- a/src/v1/assessor/dto/create-assessor.dto.ts
+++ b/src/v1/assessor/dto/create-assessor.dto.ts
@@ -11,7 +11,6 @@ export enum TaskType {
 
 const nonEmptyString = z.string().min(1);
 const bufferType = z.instanceof(Buffer);
-const imageObject = z.object({ path: z.string(), mimeType: z.string() });
 
 /**
  * Zod schema for validating the CreateAssessorDto.
@@ -82,16 +81,6 @@ export const assessorDtoSchema = z
          * @example "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
          */
         studentResponse: z.union([nonEmptyString, bufferType]),
-        /**
-         * An array of image objects, each with a path and mimeType.
-         * This field is used to provide additional image data related to the IMAGE taskType.
-         * Each object in the array represents an image with its file path and MIME type.
-         * @example [
-         *   { path: "/images/image1.png", mimeType: "image/png" },
-         *   { path: "/images/image2.jpg", mimeType: "image/jpeg" }
-         * ]
-         */
-        images: z.array(imageObject).optional(),
         systemPromptFile: z.string().optional(),
       })
       .strict(),

--- a/test/pentesting.e2e-spec.ts
+++ b/test/pentesting.e2e-spec.ts
@@ -93,7 +93,7 @@ describe('Penetration Testing (e2e)', () => {
       .set('Authorization', `Bearer ${app.apiKey}`)
       .send(payload)
       .expect(400);
-    expect(response.body.message).toBe('Invalid base64 string format.');
+    expect(response.body.message).toBe('Image data must be a valid data URI.');
   });
 
   it('should not allow CORS from arbitrary origins', async () => {


### PR DESCRIPTION
## Summary

Remediate the findings in `CODE_REVIEW.md` for the AssessmentBot LLM service.
This branch resolves every Security, Performance, Compliance, and Latent Bugs
finding raised in the review, via ten focused change units, each implemented,
reviewed, and committed individually.

## Change Units

| #  | Commit    | Unit |
|----|-----------|------|
| 1  | `2405391` | Secret-leak hardening — redact API-key value in logs and `x-api-key` header; strict format enforcement |
| 2  | `5eb51af` | Remove the unused file-based IMAGE path; consolidate on Buffer / data-URI flows and the `IMAGE` pipe |
| 3  | `2004aa9` | Cache static prompt template reads to avoid per-request disk I/O |
| 4  | `b20cdfa` | Dedupe `buildModelParams` / `buildContents`; lazy `logger.debug` / `verbose`; MIME `Set` |
| 5  | `908c25e` | Enforce British English across the codebase; fix `jsonrepair` doc reference |
| 6  | `d4d23e9` | Route `process.env` access through `ConfigService`; add `LOG_FILE` schema entry |
| 7  | `0606c7b` | Remove unused dependencies (`@modelcontextprotocol/sdk`, `@openai/codex-sdk`) |
| 8  | `43b3568` | Switch rate-limiting to be keyed by API key rather than client IP |
| 9  | `7dad3c4` | Fix latent LLM / JSON parsing bugs (retry error shape, brace scan, ZodError log) |
| 10 | `b6a4753` | Document the four authorised `eslint-disable` overrides in `docs/development/linter-overrides.md` and cross-reference from each inline comment |

## Finding Coverage

- **Security §1** — Unit 1
- **Latent Bugs §4 M2 / M3 / LOW** — Unit 9
- **Latent Bugs L1 / L3** — closed in Unit 1
- **Performance §2 HIGH / MED** — Units 3, 4
- **Compliance §3** (linter-override authorisation) — Unit 10
- **Compliance §4 L4** (env access through ConfigService) — Unit 6
- **Cleanup / unused code** — Units 2, 7
- **Spelling** (British English uniformly) — Unit 5

The `CODE_REVIEW.md` document in the branch is the source of truth for every
finding remediated here.

## Quality Gates

- `npm run lint` — clean
- `npm run build` — succeeds
- `npm run test` — passing (271 unit tests)
- `npm run test:e2e` — passing (49 E2E tests)
- Husky `lint-staged` (eslint, prettier, British-English check) — passed on every commit

## Per-Unit Review

Each change unit passed a dedicated `code-reviewer` review before being
committed; review notes are retained from the implement / review loop.

## Notes

- One reference in `CODE_REVIEW.md` listed a fifth `eslint-disable` at
  `src/prompt/image.prompt.ts:190`; that suppression has already been
  removed by Unit 2's `eslint.config.js` exception, so the Compliance §3
  finding is fully closed without any code on this branch referring to it.
- No new dependencies were introduced; two unused packages were removed
  in Unit 7.
- Base branch is `master`. Push was intentionally withheld until PR
  creation as per the previous guardrail; user has now authorised it.